### PR TITLE
Default to latest AVR GCC via toolchain PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # AVR Toolchain Setup
 
-Run the script below to install Atmel's AVR-GCC toolchain on Ubuntu 24.04:
+Run the script below to install the AVR-GCC toolchain on Ubuntu 24.04.
+The script attempts to install the latest cross compiler available by
+enabling the *ubuntu-toolchain-r/test* PPA and searching for
+\`gcc-<version>-avr\` packages.  If none are found it falls back to the
+stock \`gcc-avr\` from the \`universe\` repository.
 
 ```bash
-sudo ./setup.sh            # installs via the pmjdebruijn PPA
+sudo ./setup.sh            # installs the newest toolchain it can find
 ```
 
-To use Ubuntu's official packages instead, pass `--official`.
+Pass `--stock` to force the script to use only Ubuntu's packages.
+Use `--old` to try the deprecated pmjdebruijn PPA on older systems.
+
+After installation, verify the toolchain versions:
+
+```bash
+avr-gcc --version
+avr-libc-config --version
+```
 
 Optimised flags for an Arduino Uno (ATmega328P):
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,13 +2,18 @@
 # ==============================================================
 #  AVR Development Environment Setup Script
 # --------------------------------------------------------------
-#  Installs the AVR toolchain on Ubuntu 24.04 "Noble". By default
-#  it pulls Atmel-branded packages from Peter de Bruijn's PPA but
-#  it can fall back to the official universe repository.
+#  Installs the AVR toolchain on Ubuntu 24.04 "Noble".
+#  By default the script attempts to install the newest cross compiler
+#  available.  It enables the *ubuntu-toolchain-r/test* PPA and searches
+#  for any gcc-<version>-avr packages.  If none are present it falls back
+#  to the stock gcc-avr package.  The historic pmjdebruijn PPA can be
+#  selected for older releases.
 #
-#  Usage: sudo ./setup.sh [--official]
+#  Usage: sudo ./setup.sh [--stock|--old]
 #
-#  Pass --official to skip the PPA and use Ubuntu's stock packages.
+#  --stock     Use Ubuntu's stock packages only.
+#  --old       Attempt to install the deprecated pmjdebruijn PPA.
+#
 #  Environment variables MCU and F_CPU may be set to customise the
 #  recommended compiler flags.
 # ==============================================================
@@ -25,16 +30,32 @@ fi
 apt-get update
 apt-get install -y software-properties-common apt-transport-https ca-certificates
 
-# Determine whether to use the PPA or the official repository.
-if [ "${1:-}" = "--official" ]; then
-    add-apt-repository -y universe
-else
-    add-apt-repository -y ppa:pmjdebruijn/avr
-fi
+# Determine which repository to enable for the compiler packages.
+case "${1:-}" in
+    --stock)
+        add-apt-repository -y universe
+        ;;
+    --old)
+        add-apt-repository -y ppa:pmjdebruijn/avr
+        ;;
+    "")
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        ;;
+    *)
+        echo "Usage: $0 [--stock|--old]" >&2
+        exit 1
+        ;;
+esac
 apt-get update
 
+# Determine the best available compiler package.
+best_pkg=$(apt-cache search gcc | grep -E '^gcc-[0-9]+-avr' | awk '{print $1}' | sort -V | tail -n 1)
+if [ -z "$best_pkg" ]; then
+    best_pkg=gcc-avr
+fi
+
 # Install the toolchain components.
-apt-get install -y gcc-avr avr-libc binutils-avr avrdude gdb-avr
+apt-get install -y "$best_pkg" avr-libc binutils-avr avrdude gdb-avr
 
 # Display compiler and library versions for verification.
 avr-gcc --version | head -n 1


### PR DESCRIPTION
## Summary
- attempt to install latest gcc-<version>-avr from ubuntu-toolchain-r PPA
- allow `--stock` to force using distro packages and `--old` for deprecated PPA
- update README to document new default behavior

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68554619ef488331afc28c7f072804f3