### PR TITLE
Default to latest AVR GCC via toolchain PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # AVR Toolchain Setup
 
-Run the script below to install Atmel's AVR-GCC toolchain on Ubuntu 24.04:
+Run the script below to install the AVR-GCC toolchain on Ubuntu 24.04.
+The script attempts to install the latest cross compiler available by
+enabling the *ubuntu-toolchain-r/test* PPA and searching for
+\`gcc-<version>-avr\` packages.  If none are found it falls back to the
+stock \`gcc-avr\` from the \`universe\` repository.
 
 ```bash
-sudo ./setup.sh            # installs via the pmjdebruijn PPA
+sudo ./setup.sh            # installs the newest toolchain it can find
 ```
 
-To use Ubuntu's official packages instead, pass `--official`.
+Pass `--stock` to force the script to use only Ubuntu's packages.
+Use `--old` to try the deprecated pmjdebruijn PPA on older systems.
+
+After installation, verify the tool versions:
+
+```bash
+avr-gcc --version
+dpkg-query -W -f 'avr-libc ${Version}\n' avr-libc
+```
 
 Optimised flags for an Arduino Uno (ATmega328P):
 


### PR DESCRIPTION
## Summary
- attempt to install latest gcc-<version>-avr from ubuntu-toolchain-r PPA
- allow `--stock` to force using distro packages and `--old` for deprecated PPA
- update README to document new default behavior
- fall back to `gcc-avr` when PPA lacks AVR packages
- print avr-libc version via `dpkg-query`

## Testing
- `bash -n setup.sh`
- `sudo bash -x setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68554619ef488331afc28c7f072804f3

## Summary by Sourcery

Default to the latest AVR GCC by enabling the ubuntu-toolchain-r/test PPA and searching for versioned gcc-*-avr packages, with options to force stock or legacy PPA installations.

New Features:
- Enable the ubuntu-toolchain-r/test PPA by default to install the newest gcc-<version>-avr cross compiler
- Add --stock and --old flags to override the default PPA selection

Enhancements:
- Fall back to the stock gcc-avr package when no versioned AVR compiler is found
- Use dpkg-query to report the installed avr-libc version

Documentation:
- Update README to describe the new default behavior and the --stock/--old flags