### PR TITLE
Define NK_LOCK_ADDR and optimization flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ CFLAGS="$CFLAGS --icf=safe -fipa-pta"
 These options enable identical code folding and a reduced
 points-to analysis for slightly smaller binaries.
 
+## Configurable Lock Address
+
+The spinlock primitives can operate on a dedicated I/O register. The
+address is set at compile time with the `NK_LOCK_ADDR` macro which
+defaults to `0x2C`.
+
+```c
+#ifndef NK_LOCK_ADDR
+#define NK_LOCK_ADDR 0x2C
+#endif
+_Static_assert(NK_LOCK_ADDR <= 0x3F, "lock must be in lower I/O");
+```
+
+Override this setting by appending a compiler flag, e.g.
+
+```bash
+meson setup build --cross-file cross/avr_m328p.txt \
+  -Dc_args="-DNK_LOCK_ADDR=0x2D"
+```
+
 Ubuntu 24.04 ships `gcc-avr` based on GCC 7.3.0 which only supports the C11
 language standard.  For bleeding-edge features one may install
 `gcc-avr-14` from the **team-gcc-arm-embedded** PPA.  The library builds

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -7,8 +7,9 @@ strip = '/usr/bin/avr-strip'
 
 [properties]
 needs_exe_wrapper = true
-c_args = ['-mmcu=atmega328p']
-link_args = ['-mmcu=atmega328p']
+c_args = ['-std=c11', '-mmcu=atmega328p', '-DF_CPU=16000000UL', '-Os',
+          '-flto', '-ffunction-sections', '-fdata-sections']
+link_args = ['-mmcu=atmega328p', '-Wl,--gc-sections', '-flto']
 
 [built-in options]
 b_staticpic = false


### PR DESCRIPTION
## Summary
- document NK_LOCK_ADDR customization
- set optimized AVR flags in cross build file
- clarify lock address macro usage

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt --reconfigure`
- `ninja -C build -t clean`
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b28b36f4833192059c904b34c160

## Summary by Sourcery

Allow configuring the lock register’s I/O address via NK_LOCK_ADDR, switch spinlock operations to use that register, enable size-optimizing AVR build flags, and update related documentation.

New Features:
- Introduce NK_LOCK_ADDR macro to customize the I/O address used for the global lock register

Enhancements:
- Refactor spinlock primitives to use a dedicated I/O register (NK_LOCK_REG) instead of a flag field
- Add optimized AVR compiler and linker flags in the cross-file to reduce binary size

Build:
- Update cross/avr_m328p.txt with AVR-specific optimization flags

Documentation:
- Document NK_LOCK_ADDR customization and usage in the README