### PR TITLE
Enhance door RPC metadata

### DIFF
--- a/include/door.h
+++ b/include/door.h
@@ -24,8 +24,41 @@ typedef struct {
 /** Shared message slab (defined in door.c). */
 extern uint8_t door_slab[128];
 
-/** Call a door by index with a pointer to the message payload. */
+/**
+ * @brief Invoke a registered door.
+ *
+ * The call stores \p msg in the shared slab, switches to the target
+ * task and blocks until that task calls ::door_return().
+ */
 void door_call(uint8_t idx, const void *msg);
+
+/**
+ * @brief Register a door descriptor for the current task.
+ *
+ * The descriptor specifies the target task, message size (in 8-byte words)
+ * and optional flags. It is stored in the per-task \c door_vec array managed
+ * by the scheduler. Indices beyond \c DOOR_SLOTS are ignored.
+ *
+ * @param idx    Slot index in the door vector.
+ * @param target Callee task identifier.
+ * @param words  Message length measured in 8-byte words.
+ * @param flags  Implementation-defined option flags.
+ */
+void door_register(uint8_t idx, uint8_t target, uint8_t words, uint8_t flags);
+
+/**
+ * @brief Return from a door invocation to the caller.
+ */
+void door_return(void);
+
+/** Obtain the message pointer passed via ::door_call. */
+const void *door_message(void);
+
+/** Return the size of the message in 8-byte words. */
+uint8_t door_words(void);
+
+/** Retrieve option flags associated with the message. */
+uint8_t door_flags(void);
 
 #ifdef __cplusplus
 }

--- a/include/task.h
+++ b/include/task.h
@@ -52,6 +52,17 @@ void scheduler_add_task(tcb_t *tcb, void (*entry)(void), void *stack);
  */
 void scheduler_run(void);
 
+/** Get the identifier of the currently running task. */
+uint8_t task_current_id(void);
+
+/**
+ * @brief Switch context to the specified task immediately.
+ *
+ * The scheduler state is updated so that the new task becomes the current
+ * one. If \p tid is out of range the call is ignored.
+ */
+void task_switch_to(uint8_t tid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/door.c
+++ b/src/door.c
@@ -1,16 +1,65 @@
 #include "door.h"
-#include <avr/io.h>
-#include <avr/interrupt.h>
+#include "task.h"
+#include <stdint.h>
 
 /* Shared message slab. Placed in .noinit so it survives soft resets. */
 uint8_t door_slab[128] __attribute__((section(".noinit")));
 
-/* Per-task door vector, defined by the scheduler. */
-extern door_t door_vec[DOOR_SLOTS];
+/*
+ * Per-task door descriptor table. Defined in task.c and indexed by
+ * [task_id][slot].
+ */
+extern door_t door_vec[MAX_TASKS][DOOR_SLOTS];
+
+/* Task id of the caller while a door is active. */
+static uint8_t door_caller;
 
 void door_call(uint8_t idx, const void *msg)
 {
+    uint8_t caller = task_current_id();
+    if (idx >= DOOR_SLOTS) {
+        return;
+    }
+
+    door_t d = door_vec[caller][idx];
     door_slab[0] = (uint16_t)msg & 0xFF;
     door_slab[1] = (uint16_t)msg >> 8;
-    (void)idx; /* placeholder for task switch */
+    door_slab[2] = d.words;
+    door_slab[3] = d.flags;
+
+    door_caller = caller;
+    task_switch_to(d.tgt_tid);
+}
+
+void door_register(uint8_t idx, uint8_t target, uint8_t words, uint8_t flags)
+{
+    uint8_t tid = task_current_id();
+    if (idx >= DOOR_SLOTS) {
+        return;
+    }
+
+    door_vec[tid][idx].tgt_tid = target;
+    door_vec[tid][idx].words   = words & 0x0F;
+    door_vec[tid][idx].flags   = flags & 0x0F;
+}
+
+void door_return(void)
+{
+    task_switch_to(door_caller);
+}
+
+const void *door_message(void)
+{
+    uint16_t ptr = door_slab[0] | ((uint16_t)door_slab[1] << 8);
+    return (const void *)(uintptr_t)ptr;
+}
+
+uint8_t door_words(void)
+{
+    return door_slab[2];
+}
+
+uint8_t door_flags(void)
+{
+    return door_slab[3];
 }


### PR DESCRIPTION
## Summary
- zero door descriptor table on scheduler init
- include message length and flags in shared door slab
- add helpers `door_message`, `door_words` and `door_flags`
- document enhanced door API

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt`
- `meson compile -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b292fce48331ad6ad191536c1783

## Summary by Sourcery

Enhance the door RPC mechanism to support richer metadata, per-task descriptor tables, and new helper APIs for message handling and scheduler integration.

New Features:
- Introduce door_register and door_return for setting up and completing door calls.
- Add door_message, door_words, and door_flags helpers to retrieve call payload pointers, lengths, and flags.
- Expose task_current_id and task_switch_to scheduler functions for managing task contexts.

Enhancements:
- Expand the shared door slab to store message length and flags alongside the payload pointer.
- Replace single-task door vector with a two-dimensional per-task descriptor table and zero it on scheduler initialization.

Documentation:
- Document the enhanced door API and new scheduler functions in headers and the monograph.