### PR TITLE
Add basic Meson tests

### DIFF
--- a/include/nk_lock.h
+++ b/include/nk_lock.h
@@ -4,7 +4,13 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <avr/interrupt.h>
+#ifdef __AVR__
+#  include <avr/interrupt.h>
+#else
+/* fallbacks for native builds */
+#  define cli() ((void)0)
+#  define sei() ((void)0)
+#endif
 
 /**
  * \file nk_lock.h

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('avrix', 'c', version: '0.1', license: 'MIT')
 
 inc = include_directories('include')
 subdir('src')
+subdir('tests')
 
 # Documentation targets
 doxygen = find_program('doxygen', required: false)

--- a/tests/flock_stress.c
+++ b/tests/flock_stress.c
@@ -1,0 +1,13 @@
+#include "nk_lock.h"
+#include <stdio.h>
+
+int main(void) {
+    nk_flock_t l;
+    nk_flock_init(&l);
+    for (int i = 0; i < 100000; ++i) {
+        nk_flock_acq(&l);
+        nk_flock_rel(&l);
+    }
+    puts("flock stress completed");
+    return 0;
+}

--- a/tests/fs_test.c
+++ b/tests/fs_test.c
@@ -1,0 +1,32 @@
+#include "fs.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(void) {
+    fs_init();
+    /* allocate first block to avoid zero as a valid block number */
+    int dummy = fs_create("dummy", 1);
+    file_t d;
+    fs_open("dummy", &d);
+    char c = 'x';
+    fs_write(&d, &c, 1);
+
+    int inum = fs_create("test", 1);
+    assert(inum >= 0);
+
+    file_t f;
+    assert(fs_open("test", &f) == 0);
+
+    const char msg[] = "hello world";
+    assert(fs_write(&f, msg, sizeof(msg)) == sizeof(msg));
+
+    f.off = 0;
+    char buf[32];
+    int r = fs_read(&f, buf, sizeof(msg));
+    assert(r == sizeof(msg));
+    assert(memcmp(buf, msg, sizeof(msg)) == 0);
+
+    puts("fs basic test passed");
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,24 @@
+fsmod = import('fs')
+avr_root = '/usr/lib/avr/include'
+inc_list = [inc]
+if fsmod.is_dir(avr_root)
+  inc_list += include_directories(avr_root)
+endif
+common_flags = ['-O2', '-Wall', '-Wextra', '-pedantic', '-std=c17',
+                '-march=native']
+
+fs_test = executable('fs_test',
+    ['fs_test.c', meson.project_source_root() / 'src/fs.c'],
+    include_directories: inc_list,
+    c_args: common_flags,
+    native: true)
+
+test('fs_basic', fs_test)
+
+flock_test = executable('flock_stress',
+    'flock_stress.c',
+    include_directories: inc_list,
+    c_args: common_flags,
+    native: true)
+
+test('flock_stress', flock_test)


### PR DESCRIPTION
## Summary
- add fs and lock stress tests
- compile tests in a new subdirectory
- enable tests from the project build
- allow host builds without AVR headers

## Testing
- `meson setup build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b299863883319f447b39456df4aa

## Summary by Sourcery

Introduce Meson-based testing infrastructure by adding filesystem and lock stress tests, integrating them into the main build, and enabling native host builds without AVR headers

Enhancements:
- Provide dummy cli()/sei() macros in nk_lock.h to allow host builds when AVR headers are unavailable

Build:
- Include a new tests subdirectory in meson.build and configure common compiler flags

Tests:
- Add fs_basic and flock_stress executables with corresponding fs_test.c and flock_stress.c files and register them as Meson test targets