### PR TITLE
Improve setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # AVR Toolchain Setup
 
 Run the script below to install the AVR-GCC toolchain on Ubuntu 24.04.
-The script attempts to install the latest cross compiler available by
-enabling the *ubuntu-toolchain-r/test* PPA and searching for
-\`gcc-<version>-avr\` packages using `apt-cache search`. If none are found it
-falls back to the stock \`gcc-avr\` from the \`universe\` repository. Recent
-versions of the toolchain are also available from the `team-gcc-arm-embedded`
-PPA which provides packages such as `gcc-avr-14`.
+By default it enables the `team-gcc-arm-embedded/avr` PPA and installs
+`gcc-avr-14`, providing modern C23 support and the latest AVR
+optimisations. Passing `--legacy` installs the stock `gcc-avr` from the
+`universe` repository instead.
 
 ```bash
 sudo ./setup.sh            # installs the newest toolchain it can find
 ```
+The script verifies each package with `dpkg -s` and performs only one
+`apt-get update` after the PPA is enabled. Supporting utilities are installed
+on demand, avoiding redundant package operations.
 This script installs the following packages:
 
 - `gcc-avr` – GNU C cross compiler
@@ -71,7 +72,7 @@ Optimised flags for an Arduino Uno (ATmega328P):
 
 ```bash
 MCU=atmega328p
-CFLAGS="-std=c11 -mmcu=$MCU -DF_CPU=16000000UL -Os -flto -ffunction-sections -fdata-sections"
+CFLAGS="-std=c23 -mmcu=$MCU -DF_CPU=16000000UL -Oz -flto -mrelax -ffunction-sections -fdata-sections -mcall-prologues"
 LDFLAGS="-mmcu=$MCU -Wl,--gc-sections -flto"
 ```
 Additional size savings can be gained with GCC 14:
@@ -83,9 +84,10 @@ These options enable identical code folding and a reduced
 points-to analysis for slightly smaller binaries.
 
 Ubuntu 24.04 ships `gcc-avr` based on GCC 7.3.0 which only supports the C11
-language standard.  For bleeding-edge features one may install
-`gcc-avr-14` from the **team-gcc-arm-embedded** PPA.  The library builds
-cleanly with either compiler but is written to remain compatible with C11.
+language standard.  Installing `gcc-avr-14` from the
+**team-gcc-arm-embedded** PPA unlocks full C23 support.
+The sources target the modern standard yet remain broadly compatible with
+C11 compilers.
 
 ## Hardware Target: Arduino Uno R3
 

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -7,8 +7,12 @@ strip = '/usr/bin/avr-strip'
 
 [properties]
 needs_exe_wrapper = true
-c_args = ['-mmcu=atmega328p']
-link_args = ['-mmcu=atmega328p']
+c_args = [
+  '-std=c23', '-mmcu=atmega328p', '-DF_CPU=16000000UL',
+  '-Oz', '-flto', '-mrelax',
+  '-ffunction-sections', '-fdata-sections', '-mcall-prologues'
+]
+link_args = ['-mmcu=atmega328p', '-Wl,--gc-sections', '-flto']
 
 [built-in options]
 b_staticpic = false

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -2,7 +2,7 @@ Toolchain Setup
 ===============
 
 The AVR development environment relies on a number of packages from the
-Ubuntu archives.  Install them with:
+Ubuntu archives. Install them with:
 
 .. code-block:: bash
 
@@ -23,6 +23,12 @@ installed with:
    sudo apt-get install meson ninja-build doxygen python3-sphinx \
         cloc cscope exuberant-ctags cppcheck graphviz
 
+Recommended optimisation flags for the ATmega328P are::
+
+   CFLAGS="-std=c23 -mmcu=atmega328p -DF_CPU=16000000UL -Oz -flto -mrelax \
+       -ffunction-sections -fdata-sections -mcall-prologues"
+   LDFLAGS="-mmcu=atmega328p -Wl,--gc-sections -flto"
+
 The documentation requires the ``breathe`` and ``exhale`` extensions
 available on PyPI:
 
@@ -31,4 +37,7 @@ available on PyPI:
    pip3 install --user breathe exhale
 
 Running the ``setup.sh`` script found in the project root installs these
-packages automatically when executed with ``sudo``.
+packages automatically when executed with ``sudo``. The script enables the
+``team-gcc-arm-embedded/avr`` repository when necessary, refreshes the
+package lists once, and verifies each required package with ``dpkg -s`` before
+installation.

--- a/meson/avr_gcc_cross.txt
+++ b/meson/avr_gcc_cross.txt
@@ -11,5 +11,9 @@ cpu = 'atmega328p'
 endian = 'little'
 
 [properties]
-c_args = ['-mmcu=atmega328p', '-DF_CPU=16000000UL', '-Os', '-flto', '-ffunction-sections', '-fdata-sections']
+c_args = [
+  '-std=c23', '-mmcu=atmega328p', '-DF_CPU=16000000UL',
+  '-Oz', '-flto', '-mrelax',
+  '-ffunction-sections', '-fdata-sections', '-mcall-prologues'
+]
 link_args = ['-mmcu=atmega328p', '-Wl,--gc-sections', '-flto']

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,10 @@
 #
 #  Usage: sudo ./setup.sh [--modern|--legacy]
 #
+#  The script verifies each package with `dpkg -s` before installation,
+#  automatically enables the required PPA, and performs a single
+#  `apt-get update` afterwards.
+#
 #  Environment variables MCU and F_CPU may be set to customise the
 #  recommended compiler flags.
 # ==============================================================
@@ -21,9 +25,13 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-# Update package lists and install supporting utilities.
-apt-get update
-apt-get install -y software-properties-common apt-transport-https ca-certificates
+
+# Ensure prerequisite utilities are installed. The `software-properties-common`
+# package provides `add-apt-repository` which allows us to enable PPAs.
+missing_prereqs=""
+if ! command -v add-apt-repository >/dev/null 2>&1; then
+    missing_prereqs="software-properties-common apt-transport-https ca-certificates"
+fi
 
 # Determine which repository to enable for the compiler packages.
 case "${1:-}" in
@@ -40,11 +48,25 @@ case "${1:-}" in
         exit 1
         ;;
 esac
+
+# Refresh package lists after adding the repository. This single update
+# precedes all package installations.
 apt-get update
 
+# Install prerequisite utilities if they were missing.
+if [ -n "$missing_prereqs" ]; then
+    # shellcheck disable=SC2086  # intentional word splitting for package list
+    apt-get install -y $missing_prereqs
+fi
+
 # Install AVR GCC, avr-libc, binutils, avrdude, gdb, simavr and tooling.
-apt-get install -y "$best_pkg" avr-libc binutils-avr avrdude gdb-avr simavr \
-    meson ninja-build doxygen python3-sphinx cloc cscope exuberant-ctags cppcheck
+to_install="$best_pkg avr-libc binutils-avr avrdude gdb-avr simavr \
+    meson ninja-build doxygen python3-sphinx cloc cscope exuberant-ctags cppcheck"
+for pkg in $to_install; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        apt-get install -y "$pkg"
+    fi
+done
 
 # Python packages for Sphinx integration
 pip3 install --break-system-packages --upgrade breathe exhale
@@ -57,9 +79,12 @@ dpkg-query -W -f 'avr-libc ${Version}\n' avr-libc
 MCU=${MCU:-atmega328p}
 F_CPU=${F_CPU:-16000000UL}
 
+compiler_opts="-std=c23 -mmcu=$MCU -DF_CPU=$F_CPU -Oz -flto -mrelax"
+compiler_opts="$compiler_opts -ffunction-sections -fdata-sections -mcall-prologues"
+
 cat <<FLAGMSG
 Recommended compiler flags:
-  CFLAGS="-mmcu=$MCU -DF_CPU=$F_CPU -Os -flto -ffunction-sections -fdata-sections"
+  CFLAGS="$compiler_opts"
   LDFLAGS="-mmcu=$MCU -Wl,--gc-sections -flto"
 FLAGMSG
 


### PR DESCRIPTION
## Summary
- clarify that setup.sh enables the GCC AVR PPA
- update README instructions to match script
- mention single update and package checks in header
- default to C23 with -Oz optimizations and AVR prologues

## Testing
- `shellcheck setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6855b2a5dd3c83318683758584bf8dea

## Summary by Sourcery

Streamline and modernize the AVR toolchain setup by automating PPA enabling, on-demand prerequisite installation, and package verification with a single update step, while defaulting to C23 optimizations and prologue flags, and update documentation to match the new behavior and modern PPA usage.

Enhancements:
- Automatically enable the GCC AVR PPA and install prerequisite utilities on demand.
- Consolidate to one `apt-get update` after adding the PPA and verify each package via `dpkg -s` before installation.
- Introduce default compiler flags using the C23 standard with `-Oz`, LTO, and AVR prologues via a dedicated `compiler_opts` variable.

Documentation:
- Update README and other documentation to describe the default `team-gcc-arm-embedded/avr` PPA, modern C23 support, single update step, `dpkg` checks, and revised CFLAGS examples.