### PR TITLE
Refine UNO architecture figure

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+doxygen
+breathe
+exhale

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,7 @@
 project = 'Avrix'
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.imgconverter',
     'breathe',
     'exhale',
 ]

--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -40,7 +40,25 @@ Communication Stack
 -------------------
 The 16U2 handles USB using NRZI encoding with bit stuffing. It provides up to
 four 64-byte endpoints. The 328P communicates with the 16U2 via USART,
-forming a virtual shared memory for buffering and protocol handling.
+forming a virtual shared memory for buffering and protocol handling. The board
+uses a two-chip arrangement as shown in :numref:`uno-arch`.
+
+.. _uno-arch:
+.. figure:: images/uno_block.svg
+   :alt: System partitioning of the ATmega328P application core and ATmega16U2 USB bridge
+
+   System-level partitioning of compute, USB and shield I/O domains.
+
+Integrated Architecture
+-----------------------
+The two-MCU arrangement allows the ATmega16U2 to focus solely on USB tasks
+while the ATmega328P runs the nanokernel and application code. A 16\,MHz
+crystal feeds both chips; the 16U2 multiplies it to 48\,MHz for full-speed
+USB. Power from VIN or USB passes through an ideal-diode MOSFET before
+fanning out to the regulators. The 328P exposes 32\,KiB of flash and 2\,KiB of
+SRAM to the nanokernel. Locks and door-based RPC provide microsecond-scale
+context switches. TinyLog-4 uses the on-chip EEPROM for wear-levelled
+persistent storage.
 
 Gaps in the Datasheets
 ----------------------

--- a/docs/source/images/uno_block.svg
+++ b/docs/source/images/uno_block.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="uno-arch" width="500" height="300" viewBox="0 0 500 300">
+  <title id="uno-arch">Arduino Uno architecture</title>
+  <style>
+    .box { fill: #BAC8FF; stroke: #000000; stroke-width: 1.5; }
+    .arrow { stroke: #000000; stroke-width: 1.5; marker-end: url(#arrowhead); fill:none; }
+    .arrow-bi { stroke: #000000; stroke-width: 1.5; marker-end: url(#arrowhead); marker-start: url(#arrowhead); fill:none; }
+    .dash { stroke-dasharray: 4 2; }
+    text { font-family: sans-serif; font-size: 14px; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#000000" stroke-linejoin="round" />
+    </marker>
+  </defs>
+  <rect x="40" y="120" width="120" height="60" class="box"/>
+  <text x="100" y="150" text-anchor="middle">ATmega16U2</text>
+
+  <rect x="220" y="80" width="160" height="140" class="box"/>
+  <text x="300" y="110" text-anchor="middle">ATmega328P</text>
+
+  <rect x="420" y="135" width="60" height="50" class="box"/>
+  <text x="450" y="165" text-anchor="middle">I/O</text>
+
+  <rect x="40" y="40" width="120" height="50" class="box"/>
+  <text x="100" y="70" text-anchor="middle">USB</text>
+
+  <line x1="100" y1="90" x2="100" y2="120" class="arrow-bi"/>
+  <g>
+    <line x1="160" y1="150" x2="220" y2="150" class="arrow-bi"/>
+    <text x="190" y="150" text-anchor="middle" font-size="12" dominant-baseline="middle">USART</text>
+  </g>
+  <g>
+    <line x1="380" y1="150" x2="420" y2="160" class="arrow"/>
+    <text x="410" y="145" text-anchor="middle" font-size="12" dominant-baseline="middle">GPIO</text>
+  </g>
+
+  <text x="100" y="220" text-anchor="middle" font-size="12">ideal-diode MOSFET</text>
+  <text x="300" y="180" text-anchor="middle" font-size="12">
+    <tspan x="300" dy="0">32 KiB Flash</tspan>
+    <tspan x="300" dy="15">2 KiB SRAM</tspan>
+  </text>
+  <text x="250" y="30" text-anchor="middle" font-size="12">16 MHz crystal</text>
+  <line x1="250" y1="35" x2="300" y2="80" class="arrow dash"/>
+  <line x1="250" y1="35" x2="100" y2="120" class="arrow dash"/>
+</svg>


### PR DESCRIPTION
## Summary
- highlight the two-chip design in hardware docs with a cross reference
- add a bidirectional arrow to the UNO block diagram
- rebuild docs successfully after generating Doxygen XML

## Testing
- `doxygen Doxyfile`
- `sphinx-build -b html docs/source build/docs`


------
https://chatgpt.com/codex/tasks/task_e_6855b2b3ced08331aa80433da0f70a52

## Summary by Sourcery

Refine the UNO block diagram in the hardware documentation and update the documentation build configuration to support the new image.

Enhancements:
- Highlight the two-chip design in the hardware docs with a cross-reference
- Add a bidirectional arrow to the UNO block diagram for clarity

Build:
- Enable the sphinx.ext.imgconverter extension for image processing
- Add doxygen, breathe, and exhale to the documentation requirements

Documentation:
- Include the updated SVG file for the UNO block diagram