### PR TITLE
Add stack guard helpers

### DIFF
--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -7,8 +7,21 @@ strip = '/usr/bin/avr-strip'
 
 [properties]
 needs_exe_wrapper = true
-c_args = ['-mmcu=atmega328p']
-link_args = ['-mmcu=atmega328p']
+c_args = [
+  '-mmcu=atmega328p',
+  '-std=gnu11',
+  '-DF_CPU=16000000UL',
+  '-Os',
+  '-flto',
+  '-ffunction-sections',
+  '-fdata-sections',
+  '-mcall-prologues'
+]
+link_args = [
+  '-mmcu=atmega328p',
+  '-Wl,--gc-sections',
+  '-flto'
+]
 
 [built-in options]
 b_staticpic = false

--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -20,8 +20,9 @@ Kernel Architecture
 
 The nanokernel reserves 10 KB of flash and under 384 B of SRAM.  Context
 switches take 35 cycles.  A round-robin scheduler drives up to eight tasks
-with 64-byte stacks.  Filesystem structures mirror Unix V7 but reside in
-RAM for simplicity.
+with 64-byte stacks.  Each stack is wrapped in 0xA5 guard bytes which the
+scheduler verifies on every context switch to detect overflow.  Filesystem
+structures mirror Unix V7 but reside in RAM for simplicity.
 
 Optimisation Techniques
 -----------------------

--- a/include/memguard.h
+++ b/include/memguard.h
@@ -1,0 +1,46 @@
+#ifndef AVR_MEMGUARD_H
+#define AVR_MEMGUARD_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file memguard.h
+ * @brief Memory guard helpers for detecting buffer overflows.
+ */
+
+/** Pattern placed at the start and end of guarded regions. */
+#define GUARD_PATTERN 0xA5U
+
+/** Number of guard bytes on either side of a buffer. */
+#define GUARD_BYTES   2U
+
+/** Initialise guard bytes around a buffer. */
+static inline void guard_init(uint8_t *mem, size_t size)
+{
+    for (size_t i = 0; i < GUARD_BYTES; ++i) {
+        mem[i] = GUARD_PATTERN;
+        mem[size - GUARD_BYTES + i] = GUARD_PATTERN;
+    }
+}
+
+/** Validate guard bytes. Returns true if intact. */
+static inline bool check_guard(const uint8_t *mem, size_t size)
+{
+    for (size_t i = 0; i < GUARD_BYTES; ++i) {
+        if (mem[i] != GUARD_PATTERN || mem[size - GUARD_BYTES + i] != GUARD_PATTERN)
+            return false;
+    }
+    return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AVR_MEMGUARD_H */

--- a/include/task.h
+++ b/include/task.h
@@ -34,6 +34,9 @@ typedef struct {
 /** Maximum number of tasks supported. */
 #define MAX_TASKS 10
 
+/** Bytes allocated for each task's stack. */
+#define TASK_STACK_SIZE 64
+
 /**
  * @brief Initialise the scheduler.
  */
@@ -43,7 +46,7 @@ void scheduler_init(void);
  * @brief Add a task to the scheduler.
  * @param tcb  Pointer to task control block.
  * @param entry Function pointer to task entry.
- * @param stack Top of stack memory.
+ * @param stack Unused; stacks are allocated internally.
  */
 void scheduler_add_task(tcb_t *tcb, void (*entry)(void), void *stack);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,5 +8,6 @@ install_headers('../include/fixed_point.h',
                 '../include/fs.h',
                 '../include/nk_lock.h',
                 '../include/door.h',
+                '../include/memguard.h',
                 '../include/task.h',
                 subdir: 'avrix')

--- a/src/task.c
+++ b/src/task.c
@@ -1,10 +1,26 @@
 #include "task.h"
 #include "door.h"
+#include "memguard.h"
+#include <string.h>
 #include <avr/interrupt.h>
 
 static tcb_t *task_list[MAX_TASKS];
 static uint8_t task_count;
 static uint8_t current_task;
+
+/* Stacks guarded by sentinels defined in memguard.h. */
+static uint8_t stacks[MAX_TASKS][TASK_STACK_SIZE + 2 * GUARD_BYTES];
+
+static void check_stacks(void)
+{
+    for (uint8_t i = 0; i < task_count; ++i) {
+        if (!check_guard(stacks[i], sizeof(stacks[i]))) {
+            /* fatal overflow detected */
+            while (1)
+                ;
+        }
+    }
+}
 
 /* Door descriptors for the current task. Placed in .noinit. */
 door_t door_vec[DOOR_SLOTS] __attribute__((section(".noinit")));
@@ -17,15 +33,24 @@ void scheduler_init(void) {
     current_task = 0;
 }
 
-void scheduler_add_task(tcb_t *tcb, void (*entry)(void), void *stack) {
+void scheduler_add_task(tcb_t *tcb, void (*entry)(void), void *stack)
+{
     if (task_count >= MAX_TASKS) {
         return;
     }
 
-    // Initialise stack frame for new task.
-    uint8_t *sp = (uint8_t *)stack;
-    *--sp = (uint16_t)entry & 0xFF;  // return address
+    (void)stack; /* stacks are allocated internally */
+
+    uint8_t *region = stacks[task_count];
+    const size_t total = sizeof(stacks[task_count]);
+    guard_init(region, total);
+    memset(region + GUARD_BYTES, 0, TASK_STACK_SIZE);
+
+    /* stack grows downward; start just below the top guard */
+    uint8_t *sp = region + GUARD_BYTES + TASK_STACK_SIZE;
+    *--sp = (uint16_t)entry & 0xFF;  /* return address */
     *--sp = (uint16_t)entry >> 8;
+
     tcb->sp = (sp_t)sp;
     tcb->state = TASK_READY;
     tcb->priority = 0;
@@ -54,6 +79,7 @@ void scheduler_run(void) {
 
     tcb_t *prev = task_list[0];
     while (1) {
+        check_stacks();
         tcb_t *next = task_list[current_task];
         if (next->state == TASK_READY) {
             next->state = TASK_RUNNING;


### PR DESCRIPTION
## Summary
- add memguard.h with GUARD_PATTERN helpers
- integrate guards into the scheduler implementation
- install the new header for external use
- mention guard checking in the monograph documentation
- tune cross file with optimisation flags

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt` *(fails: `meson` not found)*
- `meson compile -C build` *(fails: `meson` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b2cfd2908331a9290b80ac7c1eaa