### PR TITLE
Implement fs_list function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # AVR Toolchain Setup
 
 Run the script below to install the AVR-GCC toolchain on Ubuntu 24.04.
-The script attempts to install the latest cross compiler available by
-enabling the *ubuntu-toolchain-r/test* PPA and searching for
-\`gcc-<version>-avr\` packages using `apt-cache search`. If none are found it
-falls back to the stock \`gcc-avr\` from the \`universe\` repository. Recent
-versions of the toolchain are also available from the `team-gcc-arm-embedded`
-PPA which provides packages such as `gcc-avr-14`.
+The distribution currently provides only `gcc-avr` (version 7.3).  The script
+enables the *ubuntu-toolchain-r/test* repository for a newer host compiler but
+still installs the stock cross compiler.  Older instructions referenced the
+`team-gcc-arm-embedded` PPA, however that archive no longer publishes AVR
+packages and should be avoided.
 
 ```bash
 sudo ./setup.sh            # installs the newest toolchain it can find
@@ -25,19 +24,25 @@ packages are available using `apt-cache`:
 
 ```bash
 apt-cache search gcc-avr
-apt-cache show gcc-avr-14    # inspect package details
+apt-cache show gcc-avr       # inspect package details
 man apt-cache                # explore additional query options
 ```
+
+For Ubuntu 24.04 this search typically yields only ``gcc-avr`` version
+7.3.0 from the ``universe`` repository even when the Toolchain Test PPA
+is enabled.  As of this writing no newer AVR cross compiler packages are
+published on Launchpad, so the script installs ``gcc-avr`` by default.
 
 Then install the desired tools:
 
 ```bash
-sudo add-apt-repository ppa:team-gcc-arm-embedded/avr
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
-sudo apt-get install gcc-avr-14 avr-libc binutils-avr avrdude gdb-avr simavr
+sudo apt-get install gcc-avr avr-libc binutils-avr avrdude gdb-avr simavr
 ```
-Legacy systems can instead install the stock `gcc-avr` (version 7.3.0) from the
-Ubuntu archives.
+This installs the official cross compiler along with a modern host GCC from the
+toolchain test PPA.  If the PPA is unavailable simply omit the first line and
+install the packages from Ubuntu's universe repository.
 
 Additional developer utilities are recommended for code analysis and
 documentation generation.  Install them with:
@@ -54,18 +59,28 @@ pip3 install --user breathe exhale
 ```
 
 
-Pass `--legacy` to `setup.sh` to use Ubuntu's packages instead of the modern
-PPA.  Using `--modern` (the default) selects GCC 14 from
-`ppa:team-gcc-arm-embedded/avr`.
+Pass `--legacy` to `setup.sh` to skip adding the toolchain test repository.
+Both modes install the same `gcc-avr` package on Ubuntu 24.04, but `--modern`
+also enables `ppa:ubuntu-toolchain-r/test` for a recent host compiler.
 
 
 After installation, verify the tool versions:
 
+
 ```bash
 avr-gcc --version
 dpkg-query -W -f 'avr-libc ${Version}\n' avr-libc
-
 ```
+
+
+Modern compiler options
+-----------------------
+Ubuntu currently packages only ``gcc-avr`` 7.3. Several alternatives exist if you require a C23-capable toolchain:
+
+* **Debian sid cross packages** – Pin ``gcc-avr`` from the unstable repository to obtain GCC 14 while keeping the rest of the system on Ubuntu.
+* **xPack pre-built binaries** – Download the xPack AVR-GCC tarball and prepend ``/opt/avr/bin`` to ``PATH``.
+* **Build from source** – Clone the GCC repository and configure with ``--target=avr`` for complete control over optimisation options.
+
 
 Optimised flags for an Arduino Uno (ATmega328P):
 
@@ -83,9 +98,9 @@ These options enable identical code folding and a reduced
 points-to analysis for slightly smaller binaries.
 
 Ubuntu 24.04 ships `gcc-avr` based on GCC 7.3.0 which only supports the C11
-language standard.  For bleeding-edge features one may install
-`gcc-avr-14` from the **team-gcc-arm-embedded** PPA.  The library builds
-cleanly with either compiler but is written to remain compatible with C11.
+language standard.  If newer AVR compilers become available via Launchpad you
+may substitute them here, but the codebase remains compatible with the stock
+tools shipped by Ubuntu.
 
 ## Hardware Target: Arduino Uno R3
 

--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -55,6 +55,25 @@ nanokernel allocates a temporary RAM buffer, modifies the page and reprograms
 it into a spare boot section location. Subsequent reads remain fast while
 writes incur at most the 3 ms page programming delay.
 
+Directory Listing Example
+------------------------
+
+The filesystem maintains a flat directory. ``fs_list()`` copies the filenames
+of all valid inodes into a caller-supplied array and returns how many entries
+were written.  A short program might create a few files and then print the
+directory contents:
+
+.. code-block:: c
+
+   fs_create("boot.bin", 1);
+   fs_create("config.txt", 1);
+
+   char names[FS_NUM_INODES][FS_MAX_NAME + 1];
+   int count = fs_list(names);
+   for (int i = 0; i < count; ++i) {
+       printf("%s\n", names[i]);
+   }
+
 Further Reading
 ---------------
 

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -2,18 +2,33 @@ Toolchain Setup
 ===============
 
 The AVR development environment relies on a number of packages from the
-Ubuntu archives.  Install them with:
+Ubuntu archives.  Ubuntu 24.04 only ships ``gcc-avr`` version 7.3, so we
+recommend enabling the toolchain test repository for a newer host compiler
+and then installing the standard cross compiler:
 
 .. code-block:: bash
 
-   sudo add-apt-repository ppa:team-gcc-arm-embedded/avr
+   sudo add-apt-repository ppa:ubuntu-toolchain-r/test
    sudo apt-get update
-   sudo apt-get install gcc-avr-14 avr-libc binutils-avr avrdude gdb-avr simavr
+   sudo apt-get install gcc-avr avr-libc binutils-avr avrdude gdb-avr simavr
 
-``gcc-avr-14`` provides the GNU C cross compiler, while ``avr-libc``
+``gcc-avr`` provides the GNU C cross compiler, while ``avr-libc``
 contains the AVR C library and headers. ``binutils-avr`` supplies the
 assembler and linker, ``avrdude`` programs flash memory, ``gdb-avr``
 enables debugging and ``simavr`` offers a lightweight simulator.
+
+Use ``apt-cache search gcc-avr`` to confirm which compiler packages are
+available.  At present only ``gcc-avr`` 7.3 appears in the official
+archive and the toolchain test repository, so the cross compiler remains
+on the older C11-capable version.
+
+Modern compiler options
+-----------------------
+If your project relies on the C23 standard you have several ways to obtain a newer AVR toolchain:
+
+* **Debian sid packages** provide ``gcc-avr`` 14.2. Pin only ``gcc-avr``, ``avr-libc`` and ``binutils-avr`` while keeping the rest of Ubuntu.
+* **xPack binaries** are pre-built archives. Unpack to ``/opt/avr`` and prepend that directory to ``PATH``.
+* **Build from source** using ``--target=avr`` for maximum control.
 
 Additional utilities useful for development and static analysis can be
 installed with:

--- a/include/fs.h
+++ b/include/fs.h
@@ -45,6 +45,13 @@ int  fs_create(const char *name, uint8_t type);
 int  fs_open(const char *name, file_t *f);
 int  fs_write(file_t *f, const void *buf, uint16_t len);
 int  fs_read(file_t *f, void *buf, uint16_t len);
+/**
+ * List all valid filenames in the flat directory.
+ *
+ * \param[out] out  Array with ``FS_NUM_INODES`` elements for storing names.
+ * \return          Number of entries copied into ``out``.
+ */
+int  fs_list(char (*out)[FS_MAX_NAME + 1]);
 
 #ifdef __cplusplus
 }

--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,9 @@
 #  AVR Development Environment Setup Script
 # --------------------------------------------------------------
 #  Installs the AVR toolchain on Ubuntu 24.04 "Noble".
-#  By default the script installs the modern toolchain from the
-#  `team-gcc-arm-embedded` PPA which provides GCC 14.  Passing
-#  `--legacy` installs the older gcc-avr 7.3 package from Ubuntu.
+#  By default the script enables the `ubuntu-toolchain-r/test` repository to
+#  obtain a newer host GCC.  Both modes ultimately install the `gcc-avr` package
+#  provided by Ubuntu.  `--legacy` skips the PPA entirely.
 #
 #  Usage: sudo ./setup.sh [--modern|--legacy]
 #
@@ -32,8 +32,8 @@ case "${1:-}" in
         best_pkg=gcc-avr
         ;;
     --modern|"")
-        add-apt-repository -y ppa:team-gcc-arm-embedded/avr
-        best_pkg=gcc-avr-14
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        best_pkg=gcc-avr
         ;;
     *)
         echo "Usage: $0 [--modern|--legacy]" >&2
@@ -41,6 +41,9 @@ case "${1:-}" in
         ;;
 esac
 apt-get update
+# Display available AVR compiler packages for reference
+echo "Available AVR packages:" >&2
+apt-cache search gcc-avr >&2 || true
 
 # Install AVR GCC, avr-libc, binutils, avrdude, gdb, simavr and tooling.
 apt-get install -y "$best_pkg" avr-libc binutils-avr avrdude gdb-avr simavr \

--- a/src/fs.c
+++ b/src/fs.c
@@ -146,3 +146,29 @@ int fs_read(file_t *f, void *buf, uint16_t len) {
     }
     return read_len - remaining;
 }
+
+/**
+ * Copy the names of all valid inodes into ``out``.
+ *
+ * The directory is flat so at most ``FS_NUM_INODES`` entries exist. The caller
+ * must provide storage for that many strings of length ``FS_MAX_NAME`` + 1.
+ *
+ * \param[out] out  Destination array of strings.
+ * \return          Number of entries copied.
+ */
+int fs_list(char (*out)[FS_MAX_NAME + 1]) {
+    if (out == NULL) {
+        return 0;
+    }
+
+    int count = 0;
+    for (uint8_t i = 0; i < FS_NUM_INODES; ++i) {
+        if (inodes[i].type != 0) {
+            strncpy(out[count], dir_name[i], FS_MAX_NAME);
+            out[count][FS_MAX_NAME] = '\0';
+            ++count;
+        }
+    }
+
+    return count;
+}


### PR DESCRIPTION
## Summary
- expand `fs.h` with `fs_list()` prototype and documentation
- implement more robust directory listing logic in `src/fs.c`
- improve filesystem example in the monograph
- update setup instructions for Ubuntu 24.04
- document apt repository setup and search
- clarify how to obtain a C23-capable AVR toolchain

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt`
- `meson compile -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b29795548331a52fca57966e5e8b