### PR TITLE
Add q8_8_mul boundary tests

### DIFF
--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -36,6 +36,16 @@ Resource Accounting
 Total flash usage is under 28 KB leaving space for user programs.  SRAM is
 statically partitioned: 640 B kernel, 640 B shell, 512 B stacks, 256 B heap.
 
+Fixed-Point Format
+------------------
+
+Arithmetic routines use a signed Q8.8 format. The high byte stores the
+integer part while the low byte holds the fractional bits. A value of
+``0x0100`` represents one while ``0xFF00`` encodes ``-1``. The usable
+range is roughly ``-128`` to ``127.996``. Multiplication keeps the
+middle 16 bits of the 32-bit product with rounding so every step
+remains purely 8-bit.
+
 Descriptor-Based RPC
 --------------------
 

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('avrix', 'c', version: '0.1', license: 'MIT')
 
 inc = include_directories('include')
 subdir('src')
+subdir('tests')
 
 # Documentation targets
 doxygen = find_program('doxygen', required: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,9 @@
-sources = files('fixed_point.c', 'fs.c', 'door.c', 'task.c')
+if meson.is_cross_build()
+  sources = files('fixed_point.c', 'fs.c', 'door.c', 'task.c')
+else
+  sources = files('fixed_point.c', 'fs.c')
+endif
+
 libavrix = static_library('avrix', sources,
     include_directories : inc,
     install : true

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,6 @@
+test_exe = executable('test_fixed_point', 'test_fixed_point.c',
+    link_with : libavrix,
+    include_directories : inc)
+
+
+test('q8_8_mul_boundaries', test_exe)

--- a/tests/test_fixed_point.c
+++ b/tests/test_fixed_point.c
@@ -1,0 +1,32 @@
+#include "fixed_point.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* Convenience constants for the Q8.8 type.  */
+#define Q8_8_ONE      ((q8_8_t)0x0100)
+#define Q8_8_NEG_ONE  ((q8_8_t)-0x0100)
+#define Q8_8_MAX      INT16_MAX
+#define Q8_8_MIN      INT16_MIN
+
+static void boundary_tests(void)
+{
+    assert(q8_8_mul(Q8_8_MAX, Q8_8_ONE) == Q8_8_MAX);
+    assert(q8_8_mul(Q8_8_MIN, Q8_8_ONE) == Q8_8_MIN);
+    assert(q8_8_mul(Q8_8_MAX, Q8_8_MIN) == (q8_8_t)0x8081);
+    assert(q8_8_mul(Q8_8_MIN, Q8_8_MIN) == (q8_8_t)0x0000);
+    assert(q8_8_mul(Q8_8_ONE, Q8_8_ONE) == Q8_8_ONE);
+    assert(q8_8_mul(Q8_8_MAX, 0) == 0);
+    assert(q8_8_mul(Q8_8_MIN, 0) == 0);
+    assert(q8_8_mul(Q8_8_NEG_ONE, Q8_8_NEG_ONE) == Q8_8_ONE);
+    assert(q8_8_mul(Q8_8_MAX, Q8_8_NEG_ONE) == (q8_8_t)0x8101);
+    assert(q8_8_mul(Q8_8_MIN, Q8_8_NEG_ONE) == Q8_8_MIN);
+    assert(q8_8_mul(Q8_8_NEG_ONE, Q8_8_ONE) == Q8_8_NEG_ONE);
+}
+
+int main(void)
+{
+    boundary_tests();
+    puts("q8_8_mul boundary tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- exercise `q8_8_mul` with edge cases
- include the new program in Meson's tests
- document the Q8.8 fixed-point representation
- skip AVR-only sources when building for the host

## Testing
- `meson setup build --reconfigure`
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b2d495888331b4c37d90f152dd00

## Summary by Sourcery

Integrate a new boundary test suite for q8_8_mul, update the Meson build to include the tests and skip AVR-only sources on non-cross builds, and enhance documentation with Q8.8 fixed-point format details.

Build:
- Conditionally exclude AVR-only sources on host builds.
- Include the tests subdirectory in the Meson build.

Documentation:
- Document the Q8.8 fixed-point representation in the project monograph.

Tests:
- Add boundary tests for q8_8_mul to validate edge cases.