### PR TITLE
Update toolchain docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ language standard.  For bleeding-edge features one may install
 `gcc-avr-14` from the **team-gcc-arm-embedded** PPA.  The library builds
 cleanly with either compiler but is written to remain compatible with C11.
 
+### Legacy vs Modern GCC
+
+The `--legacy` option to `setup.sh` installs the stock 7.3 compiler, while
+`--modern` (the default) pulls in GCC 14 from the PPA.  The newer compiler
+understands the C23 standard and unlocks link-time optimisations such as
+``--icf=safe``.  Source files that rely on C23 features should guard those
+sections with ``#if __STDC_VERSION__ >= 202311L`` so the code still builds
+with the older toolchain.
+
+```bash
+sudo ./setup.sh --modern   # install GCC 14 with C23 support
+sudo ./setup.sh --legacy   # fallback to GCC 7.3
+```
+
 ## Hardware Target: Arduino Uno R3
 
 Avrix is designed around the **Arduino Uno R3**, which combines an

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -32,3 +32,21 @@ available on PyPI:
 
 Running the ``setup.sh`` script found in the project root installs these
 packages automatically when executed with ``sudo``.
+
+Legacy vs Modern GCC
+--------------------
+
+``gcc-avr`` in Ubuntu 24.04 is version 7.3 and supports the C11 standard.
+The ``team-gcc-arm-embedded`` PPA provides ``gcc-avr-14`` with full C23
+support, improved link-time optimisation and additional size-reduction
+flags like ``--icf=safe`` and ``-fipa-pta``.  The project builds with
+either compiler, but code relying on new C23 features must be conditionally
+compiled when using the legacy toolchain.
+
+Switch the compiler during setup by passing ``--modern`` (default) or
+``--legacy`` to ``setup.sh``:
+
+.. code-block:: bash
+
+   sudo ./setup.sh --modern   # install GCC 14
+   sudo ./setup.sh --legacy   # install GCC 7.3

--- a/include/compat.h
+++ b/include/compat.h
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef AVR_COMPAT_H
+#define AVR_COMPAT_H
+
+#if __STDC_VERSION__ >= 202311L
+#  define AVR_UNUSED [[maybe_unused]]
+#else
+#  define AVR_UNUSED __attribute__((unused))
+#endif
+
+#endif /* AVR_COMPAT_H */

--- a/include/door.h
+++ b/include/door.h
@@ -2,6 +2,7 @@
 #define AVR_DOOR_H
 
 #include <stdint.h>
+#include "compat.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +26,7 @@ typedef struct {
 extern uint8_t door_slab[128];
 
 /** Call a door by index with a pointer to the message payload. */
-void door_call(uint8_t idx, const void *msg);
+void door_call(uint8_t idx AVR_UNUSED, const void *msg);
 
 #ifdef __cplusplus
 }

--- a/src/door.c
+++ b/src/door.c
@@ -1,4 +1,5 @@
 #include "door.h"
+#include "compat.h"
 #include <avr/io.h>
 #include <avr/interrupt.h>
 
@@ -8,9 +9,8 @@ uint8_t door_slab[128] __attribute__((section(".noinit")));
 /* Per-task door vector, defined by the scheduler. */
 extern door_t door_vec[DOOR_SLOTS];
 
-void door_call(uint8_t idx, const void *msg)
+void door_call(uint8_t idx AVR_UNUSED, const void *msg)
 {
     door_slab[0] = (uint16_t)msg & 0xFF;
     door_slab[1] = (uint16_t)msg >> 8;
-    (void)idx; /* placeholder for task switch */
 }


### PR DESCRIPTION
## Summary
- describe GCC 14 vs 7.3 toolchains
- document switching compilers with setup.sh
- add C23 compatibility header and mark door_call arg as unused

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt`
- `ninja -C build`


------
https://chatgpt.com/codex/tasks/task_e_6855b2e6c1c48331b6d34b9121d33cb2

## Summary by Sourcery

Document toolchain selection options and introduce a C23 compatibility helper for marking unused parameters

Enhancements:
- Add compat.h header defining AVR_UNUSED as either [[maybe_unused]] or __attribute__((unused)) based on C23 support
- Annotate door_call’s idx parameter with AVR_UNUSED and include compat.h in door.c and door.h

Documentation:
- Add a "Legacy vs Modern GCC" section to README explaining setup.sh flags for GCC 7.3 (legacy) and GCC 14 (modern)