### PR TITLE
Add resilient CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+# Continuous integration workflow for Avrix
+# Uses the setup script to install the AVR toolchain and
+# builds the project using Meson. Documentation is exported
+# as an artifact for each run.
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository sources
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install AVR GCC toolchain and required build utilities
+      - name: Install AVR toolchain
+        run: sudo ./setup.sh --legacy
+
+      # Configure the Meson build directory for the AVR target
+      - name: Configure build
+        run: meson setup build --cross-file cross/avr_m328p.txt
+
+      # Compile all targets using ninja via Meson
+      - name: Compile
+        run: meson compile -C build
+
+      # Execute any unit tests defined in the project
+      - name: Run tests
+        run: meson test -C build --print-errorlogs
+
+      # Generate Doxygen and Sphinx documentation
+      - name: Build documentation
+        run: meson compile -C build doc-doxygen doc-sphinx
+
+      # Archive the built documentation for inspection
+      - name: Upload docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: build/docs
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AVR Toolchain Setup
 
 Run the script below to install the AVR-GCC toolchain on Ubuntu 24.04.
-The script attempts to install the latest cross compiler available by
-enabling the *ubuntu-toolchain-r/test* PPA and searching for
-\`gcc-<version>-avr\` packages using `apt-cache search`. If none are found it
-falls back to the stock \`gcc-avr\` from the \`universe\` repository. Recent
-versions of the toolchain are also available from the `team-gcc-arm-embedded`
-PPA which provides packages such as `gcc-avr-14`.
+The helper first attempts to use the modern packages from
+`ppa:team-gcc-arm-embedded/avr`. When that repository cannot be
+reached, the script automatically falls back to the stock `gcc-avr`
+package from the `universe` archive. Recent versions of the toolchain
+are also available from the `team-gcc-arm-embedded` PPA which provides
+packages such as `gcc-avr-14`.
 
 ```bash
 sudo ./setup.sh            # installs the newest toolchain it can find
@@ -19,6 +19,7 @@ This script installs the following packages:
 - `avrdude` – firmware programmer
 - `gdb-avr` – debugger
 - `simavr` – lightweight simulator
+- `graphviz` – diagram generation utility used by Doxygen
 
 To install them manually without the script first discover which GCC
 packages are available using `apt-cache`:
@@ -54,9 +55,10 @@ pip3 install --user breathe exhale
 ```
 
 
-Pass `--legacy` to `setup.sh` to use Ubuntu's packages instead of the modern
-PPA.  Using `--modern` (the default) selects GCC 14 from
-`ppa:team-gcc-arm-embedded/avr`.
+Passing `--legacy` forces the use of Ubuntu's packages instead of the
+modern toolchain.  When invoked without arguments the script attempts
+the modern PPA first and transparently reverts to `gcc-avr` if that
+repository is unreachable.
 
 
 After installation, verify the tool versions:
@@ -103,7 +105,8 @@ The project uses **Meson** in combination with a cross file to build
 the AVR binaries.  Two examples are supplied:
 
 - `meson/avr_gcc_cross.txt` – minimal flags
-- `cross/avr_m328p.txt` – full example with absolute tool paths
+- `cross/avr_m328p.txt` – full example with absolute tool paths and
+  optimisation flags tuned for the ATmega328P
 
 ```bash
 meson setup build --cross-file cross/avr_m328p.txt

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -7,8 +7,9 @@ strip = '/usr/bin/avr-strip'
 
 [properties]
 needs_exe_wrapper = true
-c_args = ['-mmcu=atmega328p']
-link_args = ['-mmcu=atmega328p']
+c_args = ['-std=c11', '-mmcu=atmega328p', '-DF_CPU=16000000UL', '-Os',
+  '-flto', '-ffunction-sections', '-fdata-sections']
+link_args = ['-mmcu=atmega328p', '-Wl,--gc-sections', '-flto']
 
 [built-in options]
 b_staticpic = false

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -31,4 +31,5 @@ available on PyPI:
    pip3 install --user breathe exhale
 
 Running the ``setup.sh`` script found in the project root installs these
-packages automatically when executed with ``sudo``.
+packages automatically.  The script attempts the modern PPA first and
+falls back to ``gcc-avr`` if that repository is not accessible.

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,10 @@ subdir('src')
 # Documentation targets
 doxygen = find_program('doxygen', required: false)
 if doxygen.found()
-  run_target('doc-doxygen', command: [doxygen, meson.current_source_dir() / 'Doxyfile'])
+  run_target('doc-doxygen',
+    command: ['sh', '-c',
+      'cd ' + meson.current_source_dir() + ' && ' + doxygen.path() + ' Doxyfile']
+  )
 endif
 
 sphinx = find_program('sphinx-build', required: false)

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,8 @@
 #  Installs the AVR toolchain on Ubuntu 24.04 "Noble".
 #  By default the script installs the modern toolchain from the
 #  `team-gcc-arm-embedded` PPA which provides GCC 14.  Passing
-#  `--legacy` installs the older gcc-avr 7.3 package from Ubuntu.
+#  `--legacy` installs the older gcc-avr 7.3 package from Ubuntu.  The script
+#  automatically falls back to this legacy toolchain if the PPA is unavailable.
 #
 #  Usage: sudo ./setup.sh [--modern|--legacy]
 #
@@ -43,8 +44,12 @@ esac
 apt-get update
 
 # Install AVR GCC, avr-libc, binutils, avrdude, gdb, simavr and tooling.
-apt-get install -y "$best_pkg" avr-libc binutils-avr avrdude gdb-avr simavr \
-    meson ninja-build doxygen python3-sphinx cloc cscope exuberant-ctags cppcheck
+if ! apt-get install -y "$best_pkg" avr-libc binutils-avr avrdude gdb-avr simavr \
+    meson ninja-build doxygen python3-sphinx cloc cscope exuberant-ctags cppcheck graphviz; then
+    echo "Falling back to gcc-avr" >&2
+    apt-get install -y gcc-avr avr-libc binutils-avr avrdude gdb-avr simavr \
+        meson ninja-build doxygen python3-sphinx cloc cscope exuberant-ctags cppcheck graphviz
+fi
 
 # Python packages for Sphinx integration
 pip3 install --break-system-packages --upgrade breathe exhale


### PR DESCRIPTION
## Summary
- add CI workflow calling setup script in legacy mode
- install graphviz and handle fallback to Ubuntu packages in setup script
- tune AVR cross file with optimized C flags
- document automatic toolchain fallback in README and docs
- run Doxygen from project root in Meson

## Testing
- `meson setup build --cross-file cross/avr_m328p.txt`
- `meson compile -C build`
- `meson test -C build --print-errorlogs`
- `meson compile -C build doc-doxygen doc-sphinx`


------
https://chatgpt.com/codex/tasks/task_e_6855b2e86f208331b06b1b3e7082e1a6