### PR TITLE
Add simavr filesystem demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,22 @@ comments via the `breathe` and `exhale` extensions.
 
 Use `setup.sh` or the manual commands above to install the compiler
 before configuring Meson.
+
+## Example: File System Demo
+
+An example program demonstrating the in-memory filesystem lives in
+`examples/fs_demo.c`. Build it along with the library using Meson. The program
+stores a greeting and prints it back:
+
+```bash
+meson setup build --cross-file cross/avr_m328p.txt
+meson compile -C build fs_demo_hex
+```
+
+Both the ELF and HEX images are written to `build/examples`.
+
+Run the resulting binary under `simavr` for quick testing:
+
+```bash
+simavr -m atmega328p build/examples/fs_demo
+```

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -7,8 +7,9 @@ strip = '/usr/bin/avr-strip'
 
 [properties]
 needs_exe_wrapper = true
-c_args = ['-mmcu=atmega328p']
-link_args = ['-mmcu=atmega328p']
+c_args = ['-mmcu=atmega328p', '-DF_CPU=16000000UL', '-Os', '-flto',
+          '-ffunction-sections', '-fdata-sections']
+link_args = ['-mmcu=atmega328p', '-Wl,--gc-sections', '-flto']
 
 [built-in options]
 b_staticpic = false

--- a/examples/fs_demo.c
+++ b/examples/fs_demo.c
@@ -1,0 +1,41 @@
+#include "fs.h"
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * Minimal demonstration of the in-memory filesystem. The program creates
+ * a file, writes a string to it and then reads the contents back. When run
+ * under simavr the greeting will be printed to the simulator console.
+ */
+
+int main(void)
+{
+    fs_init();
+
+    /* Create a regular file named greeting.txt. */
+    if (fs_create("greeting.txt", 1) < 0) {
+        puts("create failed");
+        return 1;
+    }
+
+    file_t f;
+    if (fs_open("greeting.txt", &f) != 0) {
+        puts("open failed");
+        return 1;
+    }
+
+    const char msg[] = "Hello from Avrix";
+    if (fs_write(&f, msg, strlen(msg)) != (int)strlen(msg)) {
+        puts("write failed");
+        return 1;
+    }
+
+    /* Rewind and read the contents back. */
+    f.off = 0;
+    char buf[32];
+    int n = fs_read(&f, buf, sizeof buf - 1);
+    buf[n] = '\0';
+
+    printf("%s\n", buf);
+    return 0;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,17 @@
+fs_demo = executable(
+  'fs_demo',
+  'fs_demo.c',
+  include_directories: inc,
+  link_with: libavrix,
+  c_args: ['-Wall', '-Wextra'],
+  install: false
+)
+
+# Convert ELF to Intel HEX for use with simavr or avrdude
+objcopy = find_program('avr-objcopy', required: false)
+if objcopy.found()
+  custom_target('fs_demo_hex',
+    command: [objcopy, '-O', 'ihex', '@INPUT@', '@OUTPUT@'],
+    input: fs_demo,
+    output: 'fs_demo.hex')
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,13 @@
-project('avrix', 'c', version: '0.1', license: 'MIT')
+project(
+  'avrix', 'c',
+  version: '0.1',
+  license: 'MIT',
+  default_options: ['c_std=c11', 'warning_level=2']
+)
 
 inc = include_directories('include')
 subdir('src')
+subdir('examples')
 
 # Documentation targets
 doxygen = find_program('doxygen', required: false)

--- a/src/fs.c
+++ b/src/fs.c
@@ -28,6 +28,7 @@ static int balloc(void) {
 }
 
 /** Helper: free a previously allocated block. */
+static void bfree(uint8_t b) __attribute__((unused));
 static void bfree(uint8_t b) {
     bitmap[b >> 3] &= ~(1u << (b & 7));
 }


### PR DESCRIPTION
## Summary
- provide `fs_demo.c` and Meson glue under `examples`
- build the example when configuring Meson
- document how to build and run the demo with `simavr`
- refine the demo with error handling and comments
- improve compiler flags in the cross file

## Testing
- `apt-get install -y meson`
- `meson setup build --cross-file cross/avr_m328p.txt` *(fails: /usr/bin/avr-gcc not found)*
- `meson compile -C build` *(fails: not a build directory)*
- `meson compile fs_demo_hex -C build` *(fails: not a build directory)*


------
https://chatgpt.com/codex/tasks/task_e_6855b2ea6f90833181375f08dc0bce1f