### PR TITLE
Add docs reference checker test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,9 @@ project('avrix', 'c', version: '0.1', license: 'MIT')
 inc = include_directories('include')
 subdir('src')
 
+# Add unit and integration tests
+subdir('tests')
+
 # Documentation targets
 doxygen = find_program('doxygen', required: false)
 if doxygen.found()

--- a/tests/check_docs.py
+++ b/tests/check_docs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Verify that all Sphinx toctree references resolve to existing files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Paths ---------------------------------------------------------------------
+# Documentation source directory and main index file.
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs" / "source"
+INDEX_FILE = DOCS_DIR / "index.rst"
+
+
+def parse_references(index_path: Path) -> list[str]:
+    """Return references from all ``.. toctree::`` blocks within *index_path*.
+
+    The parser intentionally ignores directive options such as ``:maxdepth:``
+    and supports multiple toctree blocks.
+    """
+    refs: list[str] = []
+    inside = False
+    indent: int | None = None
+
+    for line in index_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(".. toctree::"):
+            inside = True
+            indent = None
+            continue
+        if not inside:
+            continue
+        if not stripped:
+            # Blank lines are ignored within toctree blocks.
+            continue
+        if stripped.startswith(":"):
+            # Directive option (e.g., ``:maxdepth:``).
+            continue
+        if indent is None:
+            indent = len(line) - len(stripped)
+        elif len(line) - len(stripped) < indent:
+            # Dedent marks the end of the toctree block.
+            inside = False
+            indent = None
+            continue
+        refs.append(stripped)
+
+    return refs
+
+
+def check_references(refs: list[str]) -> list[Path]:
+    """Return any document paths that do not exist."""
+    missing: list[Path] = []
+    for ref in refs:
+        target = DOCS_DIR / (ref if ref.endswith(".rst") else f"{ref}.rst")
+        if not target.exists():
+            missing.append(target)
+    return missing
+
+
+def main() -> int:
+    refs = parse_references(INDEX_FILE)
+    missing = check_references(refs)
+    if missing:
+        for path in missing:
+            print(f"Missing file: {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_docs.py
+++ b/tests/check_docs.py
@@ -60,8 +60,7 @@ def check_references(refs: list[str]) -> list[Path]:
 
 def main() -> int:
     refs = parse_references(INDEX_FILE)
-    missing = check_references(refs)
-    if missing:
+    if missing := check_references(refs):
         for path in missing:
             print(f"Missing file: {path}", file=sys.stderr)
         return 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,6 @@
+python = import('python').find_installation('python3')
+
+check_docs = files('check_docs.py')
+
+test('check-docs', python, args: check_docs,
+     workdir: meson.project_source_root())


### PR DESCRIPTION
## Summary
- create tests/check_docs.py to validate referenced docs
- integrate new Python test into Meson build system
- improve test parser for multiple toctree blocks

## Testing
- `meson setup build`
- `meson test -C build --no-rebuild`


------
https://chatgpt.com/codex/tasks/task_e_6855b2eb4d0883318b51a959b50d8b50

## Summary by Sourcery

Add a new Python test to validate Sphinx documentation references and integrate it into the Meson build

Enhancements:
- Enhance toctree parser to support multiple blocks and ignore directive options

Build:
- Add tests subdirectory in Meson and integrate Python-based docs reference checker into build

Tests:
- Introduce check_docs.py to verify Sphinx toctree references and add it as a Meson test