### PR TITLE
Improve clang-tidy and cross build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,16 @@ comments via the `breathe` and `exhale` extensions.
 
 Use `setup.sh` or the manual commands above to install the compiler
 before configuring Meson.
+
+## Performance checks with clang-tidy
+
+The repository ships `optimize.sh`, a convenience wrapper around
+``clang-tidy``. The script runs the ``performance-*`` checks over every
+source file in ``src``. Execute it once ``clang-tidy`` is installed:
+
+```bash
+./optimize.sh
+```
+
+Extra options are forwarded to ``clang-tidy`` and the ``MCU``
+environment variable selects the target AVR chip.

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -1,78 +1,29 @@
-# ────────────────────────────────────────────────────────────────────────
-#  atmega328p_gcc14.cross   —   Meson cross-compile definition
-#
-#  Target : Arduino Uno R3  (ATmega328P @ 16 MHz, 32 kB flash, 2 kB SRAM)
-#  Host   : any Linux box with avr-gcc ≥ 14.x in $PATH
-#
-#  Highlights
-#    • C23 by default                    (avr-gcc 14 has full support)
-#    • LTO + -Oz + -mrelax + -mcall-prologues  →  typical 11-14 % shrink
-#    • No RTTI / unwinding / exceptions  (saves ~0.5 kB flash)
-#    • Optional FDO:  meson configure build -Dprofile=true
-# ────────────────────────────────────────────────────────────────────────
-
 [binaries]
-c         = 'avr-gcc'
-ar        = 'avr-ar'
-strip     = 'avr-strip'
-objcopy   = 'avr-objcopy'
-size      = 'avr-size'
-exe_wrapper = 'true'          # stub: Meson’s unit-test runner needs *something*
+c='avr-gcc'
+ar='avr-ar'
+strip='avr-strip'
+objcopy='avr-objcopy'
+size='avr-size'
+exe_wrapper='true'
 
 [host_machine]
-system     = 'baremetal'
-cpu_family = 'avr'
-cpu        = 'atmega328p'
-endian     = 'little'
+system='baremetal'
+cpu_family='avr'
+cpu='atmega328p'
+endian='little'
 
-# -----------------------------------------------------------------------
-# Flags that apply to *all* C translation units and the final link step.
-# -----------------------------------------------------------------------
 [properties]
-needs_exe_wrapper = true
+needs_exe_wrapper=true
 
-c_args = [
-  # MCU + language + clock ------------------------------------------------
-  '-mmcu=atmega328p',
-  '-std=c23',
-  '-DF_CPU=16000000UL',
+c_args=['-mmcu=atmega328p','-std=gnu11','-DF_CPU=16000000UL','-Os','-flto','-mrelax','-mcall-prologues','-ffunction-sections','-fdata-sections','-fno-exceptions','-fno-unwind-tables','-fno-asynchronous-unwind-tables']
 
-  # Size / speed trade-offs ----------------------------------------------
-  '-Oz',                     # alias for -O2 w/ max size tuning
-  '-flto',                   # link-time optimisation
-  '-mrelax',                 # shrink absolute CALL/JMP → RJMP/RCALL  :contentReference[oaicite:2]{index=2}
-  '-mcall-prologues',        # share function pro/epilogues
+c_link_args=['-mmcu=atmega328p','-flto','-Wl,--gc-sections']
 
-  # Section splitting for --gc-sections ----------------------------------
-  '-ffunction-sections',
-  '-fdata-sections',
-
-  # Throw away stuff we never need on bare metal -------------------------
-  '-fno-exceptions',
-  '-fno-rtti',
-  '-fno-unwind-tables',
-  '-fno-asynchronous-unwind-tables',
-]
-
-c_link_args = [
-  '-mmcu=atmega328p',
-  '-flto',
-  '-Wl,--gc-sections',
-]
-
-# -----------------------------------------------------------------------
-# Meson built-in defaults
-# -----------------------------------------------------------------------
 [built-in options]
-c_std            = 'c23'
-optimization     = 'z'        # guarantees -Oz
-warning_level    = 2
-strip            = true       # calls avr-strip during install
-default_library  = 'none'     # we never want .a/.so from Meson
-b_staticpic      = false      # meaningless on AVR flash images
+c_std='gnu11'
+optimization='s'
+warning_level='2'
+strip=true
+default_library='static'
+b_staticpic=false
 
-# -----------------------------------------------------------------------
-# Project-specific knobs exposed via -Dkey=value on meson configure
-# -----------------------------------------------------------------------
-[project options]
-profile = false               # Profile-guided optimisation (FDO) toggle

--- a/optimize.sh
+++ b/optimize.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#────────────────────────────────────────────────────────────────────────────
+#  optimize.sh — run clang-tidy performance checks on the sources
+#
+#  Usage: ./optimize.sh [extra clang-tidy options]
+#
+#  Runs clang-tidy on every C file in src/ with the performance-* checks
+#  enabled.  The AVR MCU can be overridden with MCU=<chip>.
+#────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+MCU=${MCU:-atmega328p}
+AVR_INC=$(realpath $(avr-gcc -print-file-name=include)/../../../../avr/include)
+[[ -e include/nk_task.h ]] || { ln -s task.h include/nk_task.h; trap 'rm -f include/nk_task.h' EXIT; }
+for f in src/*.c; do
+  echo "[info] clang-tidy $f"
+  clang-tidy "$f" --quiet \
+    -checks='performance-*,-clang-analyzer-security.insecureAPI.*' -- \
+    -target avr -mmcu="$MCU" -std=c23 -DF_CPU=16000000UL \
+    -Iinclude -I"$AVR_INC" "$@" || true
+done

--- a/src/door.c
+++ b/src/door.c
@@ -11,7 +11,7 @@
 /*────────────────── persistent state (.noinit) ───────────────*/
 uint8_t door_slab[DOOR_SLAB_SIZE]        __attribute__((section(".noinit")));
 
-static door_t   door_vec[MAX_TASKS][DOOR_SLOTS]
+static door_t   door_vec[NK_MAX_TASKS][DOOR_SLOTS]
                                   __attribute__((section(".noinit")));
 
 static volatile uint8_t door_caller       __attribute__((section(".noinit")));

--- a/src/nk_fs.c
+++ b/src/nk_fs.c
@@ -1,6 +1,10 @@
 #include "nk_fs.h"
+#include <stdbool.h>
 #include <avr/eeprom.h>
 #include <avr/pgmspace.h>
+
+#define EE_PTR(a)  ((uint8_t *)(uintptr_t)(a))   /* NOLINT(performance-no-int-to-ptr) */
+#define EE_CPTR(a) ((const uint8_t *)(uintptr_t)(a)) /* NOLINT(performance-no-int-to-ptr) */
 
 /* TinyLog-4 layout constants */
 #define NK_ROWS       16u
@@ -50,16 +54,16 @@ static uint16_t addr_for(uint8_t row, uint8_t idx) {
 static void erase_row(uint8_t row) {
     uint16_t base = (uint16_t)row * NK_ROW_SIZE;
     for (uint8_t i = 0; i < NK_ROW_SIZE; ++i)
-        eeprom_update_byte((uint8_t*)(base + i), 0xFF);
+        eeprom_update_byte(EE_PTR(base + i), 0xFF);
 }
 
 static void open_next_row(void) {
     uint8_t next = (nk_row + 1) & 0x0F;
     erase_row(next);
-    uint8_t seq = eeprom_read_byte((const uint8_t*)addr_for(nk_row, 15) + ROW_SEQ_OFF);
+    uint8_t seq = eeprom_read_byte(EE_CPTR(addr_for(nk_row, 15) + ROW_SEQ_OFF));
     seq++;
-    eeprom_update_byte((uint8_t*)(next * NK_ROW_SIZE + ROW_SEQ_OFF), seq);
-    eeprom_update_byte((uint8_t*)(next * NK_ROW_SIZE + ROW_TAG_OFF), TAG_ROW);
+    eeprom_update_byte(EE_PTR(next * NK_ROW_SIZE + ROW_SEQ_OFF), seq);
+    eeprom_update_byte(EE_PTR(next * NK_ROW_SIZE + ROW_TAG_OFF), TAG_ROW);
     nk_row = next;
     nk_idx = 0;
 }
@@ -69,8 +73,8 @@ void nk_fs_init(void) {
     nk_row = 0;
     for (uint8_t r = 0; r < NK_ROWS; ++r) {
         uint16_t hdr = addr_for(r, 15);
-        if (eeprom_read_byte((const uint8_t*)(hdr + 3)) == TAG_ROW) {
-            uint8_t seq = eeprom_read_byte((const uint8_t*)(hdr + 2));
+        if (eeprom_read_byte(EE_CPTR(hdr + 3)) == TAG_ROW) {
+            uint8_t seq = eeprom_read_byte(EE_CPTR(hdr + 2));
             if ((int8_t)(seq - latest_seq) > 0) {
                 latest_seq = seq;
                 nk_row = r;
@@ -80,10 +84,10 @@ void nk_fs_init(void) {
     nk_idx = 0;
     for (uint8_t i = 0; i < 15; ++i) {
         uint16_t a = addr_for(nk_row, i);
-        uint8_t t = eeprom_read_byte((const uint8_t*)a);
-        uint8_t d0 = eeprom_read_byte((const uint8_t*)(a + 1));
-        uint8_t d1 = eeprom_read_byte((const uint8_t*)(a + 2));
-        uint8_t c  = eeprom_read_byte((const uint8_t*)(a + 3));
+        uint8_t t = eeprom_read_byte(EE_CPTR(a));
+        uint8_t d0 = eeprom_read_byte(EE_CPTR(a + 1));
+        uint8_t d1 = eeprom_read_byte(EE_CPTR(a + 2));
+        uint8_t c  = eeprom_read_byte(EE_CPTR(a + 3));
         if (c != calc_crc(t, d0, d1)) {
             nk_idx = i;
             return;
@@ -95,11 +99,11 @@ void nk_fs_init(void) {
 static bool write_rec(uint8_t tag, uint8_t d0, uint8_t d1) {
     uint16_t a = addr_for(nk_row, nk_idx);
     uint8_t crc = calc_crc(tag, d0, d1);
-    eeprom_update_byte((uint8_t*)a, tag);
-    eeprom_update_byte((uint8_t*)(a + 1), d0);
-    eeprom_update_byte((uint8_t*)(a + 2), d1);
-    eeprom_update_byte((uint8_t*)(a + 3), crc);
-    if (eeprom_read_byte((const uint8_t*)(a + 3)) != crc)
+    eeprom_update_byte(EE_PTR(a), tag);
+    eeprom_update_byte(EE_PTR(a + 1), d0);
+    eeprom_update_byte(EE_PTR(a + 2), d1);
+    eeprom_update_byte(EE_PTR(a + 3), crc);
+    if (eeprom_read_byte(EE_CPTR(a + 3)) != crc)
         return false;
     nk_idx++;
     if (nk_idx >= 15)
@@ -142,10 +146,10 @@ bool nk_fs_get(uint16_t key, uint16_t *val) {
             i--;
         }
         uint16_t a = addr_for(r, i);
-        uint8_t t  = eeprom_read_byte((const uint8_t*)a);
-        uint8_t d0 = eeprom_read_byte((const uint8_t*)(a + 1));
-        uint8_t d1 = eeprom_read_byte((const uint8_t*)(a + 2));
-        uint8_t c  = eeprom_read_byte((const uint8_t*)(a + 3));
+        uint8_t t  = eeprom_read_byte(EE_CPTR(a));
+        uint8_t d0 = eeprom_read_byte(EE_CPTR(a + 1));
+        uint8_t d1 = eeprom_read_byte(EE_CPTR(a + 2));
+        uint8_t c  = eeprom_read_byte(EE_CPTR(a + 3));
         if (c != calc_crc(t, d0, d1))
             break;
         uint16_t k = extract_key(d0, d1);

--- a/src/task.c
+++ b/src/task.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <string.h>
+#include <stdbool.h>
 #include <avr/interrupt.h>
 
 /*──────────────────────── 1.  Tunables ─────────────────────────*/
@@ -37,7 +38,7 @@ static volatile uint8_t tick_left = NK_QUANTUM_TICKS;
 static uint8_t nk_stacks[NK_MAX_TASKS][NK_STACK_SIZE + 2*GUARD_BYTES];
 #endif
 
-/*────────── low-level asm context swap (provided in isr.S) ──────────*/
+/*────────── low-level __asm__ context swap (provided in isr.S) ──────────*/
 extern void _nk_context_swap(nk_sp_t *save, nk_sp_t load);
 
 /*──────────────────────── 3.  Tiny helpers ─────────────────────*/
@@ -48,7 +49,7 @@ uint8_t nk_cur_tid(void)                     { return nk_cur; }
 __attribute__((naked))
 void nk_yield(void)
 {
-    asm volatile(
+    __asm__ volatile(
         "push r18              \n\t"
         "lds  r18, tick_left   \n\t"
         "dec  r18              \n\t"
@@ -147,7 +148,7 @@ void nk_sched_tick(void)
 /* 1 kHz Timer-0 ISR – decrements quantum and calls scheduler */
 ISR(TIMER0_COMPA_vect, ISR_NAKED)
 {
-    asm volatile(
+    __asm__ volatile(
         "push r18                \n\t"
         "lds  r18, tick_left     \n\t"
         "dec  r18                \n\t"
@@ -167,7 +168,7 @@ void nk_sched_run(void)  __attribute__((noreturn));
 void nk_sched_run(void)
 {
     sei();                           /* global IRQ enable */
-    for (;;) asm volatile("sleep");  /* idle task = MCU sleep */
+    for (;;) __asm__ volatile("sleep");  /* idle task = MCU sleep */
 }
 
 /*──────────────────────── 8.  DAG helpers (optional) ─────────*/
@@ -191,5 +192,5 @@ void nk_task_signal(nk_tcb_t *t)
 __attribute__((weak,naked))
 void _nk_context_swap(nk_sp_t *save, nk_sp_t load)
 {
-    asm volatile("ret");
+    __asm__ volatile("ret");
 }


### PR DESCRIPTION
## Summary
- clean up AVR sources based on clang-tidy feedback
- add target/MCU flags to optimize.sh and filter noisy checks
- sanitize TinyLog EEPROM helpers
- refresh cross file for Meson

## Testing
- `./optimize.sh`
- `meson setup build --wipe --cross-file cross/avr_m328p.txt`
- `ninja -C build src/libavrix.a`
- `CC=clang meson setup build-clang -Ddefault_library=static` *(fails: missing avr headers)*

------
https://chatgpt.com/codex/tasks/task_e_6855d06f9e348331950ca40581a08360