### PR TITLE
Add spin lock stress test

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -79,6 +79,7 @@ test('q8_8_mul_boundaries', fp_exe)
 # ───────────────────── 3. Filesystem & lock stress tests ─────────────
 fs_test_src  = ['fs_test.c', 'sim.c'] + extra_src
 flock_src    = ['flock_stress.c', 'sim.c'] + extra_src
+spin_src     = ['spin_test.c', 'sim.c'] + extra_src
 
 if native_mode
   fs_exe = executable(
@@ -92,6 +93,14 @@ if native_mode
   flock_exe = executable(
     'flock_stress',
     flock_src,
+    link_with           : libfs,
+    include_directories : inc_list,
+    c_args              : common_cflags,
+    native              : true
+  )
+  spin_exe = executable(
+    'spin_test',
+    spin_src,
     link_with           : libfs,
     include_directories : inc_list,
     c_args              : common_cflags,
@@ -112,7 +121,15 @@ else
     include_directories : inc_list,
     c_args              : common_cflags
   )
+  spin_exe = executable(
+    'spin_test',
+    'spin_test.c',
+    link_with           : libavrix,
+    include_directories : inc_list,
+    c_args              : common_cflags
+  )
 endif
 
 test('fs_basic',    fs_exe)
 test('flock_stress', flock_exe)
+test('spin_lock',    spin_exe)

--- a/tests/spin_test.c
+++ b/tests/spin_test.c
@@ -1,0 +1,67 @@
+#include "nk_lock.h"
+#include <signal.h>
+#include <sys/time.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <time.h>
+#ifdef __x86_64__
+#include <x86intrin.h>
+#endif
+
+/* Simple 1 kHz timer interrupt counter */
+static volatile unsigned long tick_count = 0;
+
+static void on_tick(int signum)
+{
+    (void)signum;
+    ++tick_count;
+}
+
+static inline uint64_t rdcycles(void)
+{
+#if defined(__i386__) || defined(__x86_64__)
+    return __rdtsc();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
+#endif
+}
+
+int main(void)
+{
+    struct sigaction sa = {0};
+    sa.sa_handler = on_tick;
+    sigaction(SIGALRM, &sa, NULL);
+
+    /* fire every millisecond */
+    struct itimerval tv = { {0, 1000}, {0, 1000} };
+    setitimer(ITIMER_REAL, &tv, NULL);
+
+    nk_slock_t lock;
+    nk_slock_init(&lock);
+
+    const unsigned loops = 2000000u; /* two million iterations */
+    void *begin_brk = sbrk(0);
+    uint64_t worst = 0;
+
+    for (unsigned i = 0; i < loops; ++i) {
+        uint64_t t0 = rdcycles();
+        nk_slock_acq(&lock, 0);
+        nk_slock_rel(&lock);
+        uint64_t dt = rdcycles() - t0;
+        if (dt > worst)
+            worst = dt;
+    }
+
+    void *end_brk = sbrk(0);
+    /* lock operations should not allocate memory */
+    assert(begin_brk == end_brk);
+
+    printf("ticks: %lu\nworst cycles: %" PRIu64 "\n", tick_count, worst);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add spin lock stress test exercising `nk_slock_t` under timer interrupts
- build new test in `tests/meson.build`

## Testing
- `meson setup build --wipe -Doptimization=2 -Dc_std=c17` *(fails: unknown operator in meson.build)*

------
https://chatgpt.com/codex/tasks/task_e_6855e815400883319e3940b64ae17428