### PR TITLE
Implement fs_list & fs_unlink

### DIFF
--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -92,11 +92,9 @@ Wear-levelled, power-fail-safe log:
    fs_create("boot.bin",   1);
    fs_create("config.txt", 1);
 
-   char names[FS_NUM_INODES][FS_MAX_NAME + 1];
-   int n = fs_list(names);
-
-   for (int i = 0; i < n; ++i)
-       printf("%s\n", names[i]);
+   char buf[FS_NUM_INODES * (FS_MAX_NAME + 1)];
+   fs_list(buf, sizeof(buf));
+   printf("%s", buf);
 
 ----------------------------------------------------------------------
 6 · Descriptor-Based RPC (“Doors”)

--- a/include/fs.h
+++ b/include/fs.h
@@ -2,6 +2,7 @@
 #define AVR_FS_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,7 +52,24 @@ int  fs_read(file_t *f, void *buf, uint16_t len);
  * \param[out] out  Array with ``FS_NUM_INODES`` elements for storing names.
  * \return          Number of entries copied into ``out``.
  */
-int  fs_list(char (*out)[FS_MAX_NAME + 1]);
+/**
+ * Populate *buf* with a newline separated list of valid filenames.
+ *
+ * The resulting string is always NUL terminated.  Names exceeding
+ * ``len`` are truncated to fit.  The directory is flat so at most
+ * ``FS_NUM_INODES`` entries are produced.
+ *
+ * \param[out] buf  Destination buffer for the concatenated list.
+ * \param len       Buffer length in bytes.
+ * \return          Number of filenames written.
+ */
+int  fs_list(char *buf, size_t len);
+
+/** Release *name* and reclaim all associated blocks.
+ *
+ * Returns ``0`` on success or ``-1`` if the file does not exist.
+ */
+int  fs_unlink(const char *name);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- implement new `fs_list` API to return newline separated file names
- add `fs_unlink` with block reclamation
- document the new functions in `fs.h`
- adjust documentation snippet for `fs_list`

## Testing
- `meson setup build`
- `ninja -C build`
- `meson test -C build`

------
https://chatgpt.com/codex/tasks/task_e_6855e81894888331a099093953b69709