### PR TITLE
Add scheduler timer and context switch ISR

### DIFF
--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -79,12 +79,15 @@ wake-up.
 
 Scheduler Time Slice
 --------------------
-Timer/Counter0 generates a context switch interrupt every millisecond. The
-CTC mode uses ``OCR0A = 249`` with a prescaler of ``64`` at ``F_CPU =
-16\,MHz``. Each task therefore receives a 1\,ms time slice before the next
-ready task runs. ``scheduler_run()`` enables the timer and global
-interrupts before handing control to the first task. The scheduler combines
-round‑robin preemption with a
+``scheduler_init()`` programs Timer/Counter0 for a 1\,kHz tick in
+Clear Timer on Compare mode. ``OCR0A`` is calculated as
+``F_CPU / 64 / 1000 - 1`` and is compile-time checked to fit the
+8‑bit timer. With prescaler ``64`` this yields an interrupt every
+millisecond. The ``TIMER0_COMPA_vect`` handler invokes
+``context_switch()`` so each task receives a 1\,ms quantum.
+``scheduler_run()`` enables the timer and global interrupts before
+handing control to the first task.
+The scheduler combines round‑robin preemption with a
 priority search and DAG dependency tracking reminiscent of the
 ``SMF‑Meets‑Minix‑Reserrection‑DAG‑meets‑Beaatty`` hybrid. Tasks may be
 blocked on outstanding dependencies and are rescheduled automatically when

--- a/include/nk_task.h
+++ b/include/nk_task.h
@@ -71,7 +71,12 @@ _Static_assert(sizeof(nk_tcb_t) == 8,
 /*──────────────── 4. Public API ─────────────────────────*/
 
 /** Initialise scheduler, idle task & 1 kHz tick. */
-void nk_sched_init(void);
+void scheduler_init(void);
+#if defined(__GNUC__)
+void nk_sched_init(void) __attribute__((alias("scheduler_init")));
+#else
+static inline void nk_sched_init(void) { scheduler_init(); }
+#endif
 
 /**
  * Add a task to the run queue.
@@ -93,7 +98,12 @@ void nk_task_add(nk_tcb_t *tcb,
                  uint8_t class);
 
 /** Enter the scheduler – never returns. */
-void nk_sched_run(void) __attribute__((noreturn));
+void scheduler_run(void) __attribute__((noreturn));
+#if defined(__GNUC__)
+void nk_sched_run(void) __attribute__((alias("scheduler_run"), noreturn));
+#else
+static inline void nk_sched_run(void) { scheduler_run(); }
+#endif
 
 /*─ Cooperative helpers — used by locks / Doors ──────────*/
 uint8_t nk_cur_tid(void);     /**< current PID */

--- a/src/task.c
+++ b/src/task.c
@@ -21,6 +21,10 @@
 #include <stdckdint.h>
 #include <string.h>
 
+enum { TIMER0_PRESCALE = 64, TIMER0_HZ = 1000 };
+#define TIMER0_RELOAD ((F_CPU / TIMER0_PRESCALE / TIMER0_HZ) - 1)
+_Static_assert(TIMER0_RELOAD <= UINT8_MAX, "Timer0 reload exceeds 8-bit range");
+
 /*───────────────────── 1. Scheduler globals ─────────────────────*/
 
 static struct {
@@ -142,7 +146,7 @@ static inline void atomic_schedule(void)
 
 /*───────────────────── 3. Public API  ───────────────────────────*/
 
-void nk_init(void)
+void scheduler_init(void)
 {
 #if NK_OPT_STACK_GUARD
     for (nk_stack_t *s = nk_stacks; s < nk_stacks + NK_MAX_TASKS; ++s) {
@@ -150,12 +154,20 @@ void nk_init(void)
         s->guard_hi = STACK_GUARD_PATTERN;
     }
 #endif
-    /* 1 kHz tick: 16 MHz / 64 / 250 */
+    /* 1 kHz tick using Timer0 in CTC mode */
     TCCR0A = _BV(WGM01);
     TCCR0B = _BV(CS01) | _BV(CS00);
-    OCR0A  = (uint8_t)(F_CPU / 64 / 1000 - 1);
+    OCR0A  = (uint8_t)TIMER0_RELOAD;
     TIMSK0 = _BV(OCIE0A);
 }
+
+#if defined(__GNUC__)
+void nk_sched_init(void) __attribute__((alias("scheduler_init")));
+void nk_init(void)    __attribute__((alias("scheduler_init")));
+#else
+void nk_sched_init(void) { scheduler_init(); }
+void nk_init(void)    { scheduler_init(); }
+#endif
 
 bool nk_task_create(nk_tcb_t *tcb,
                     nk_task_fn entry,
@@ -199,12 +211,20 @@ bool nk_task_add(nk_tcb_t *t, void (*e)(void),
     __attribute__((alias("nk_task_create")));
 
 /* Start the scheduler (never returns) --------------------------------*/
-void nk_start(void)
+void scheduler_run(void)
 {
     sei();
     switch_to(find_next_task());
     __builtin_unreachable();
 }
+
+#if defined(__GNUC__)
+void nk_sched_run(void) __attribute__((alias("scheduler_run")));
+void nk_start(void) __attribute__((alias("scheduler_run")));
+#else
+static inline void nk_sched_run(void) { scheduler_run(); }
+static inline void nk_start(void) { scheduler_run(); }
+#endif
 
 void nk_yield(void)
 {
@@ -255,25 +275,17 @@ void nk_task_signal(uint8_t tid)
 }
 #endif /* DAG */
 
-/*───────────────────── 4. 1 kHz timer ISR ───────────────────────*/
-ISR(TIMER0_COMPA_vect, ISR_NAKED)
+/*───────────────────── 4. Timer tick & ISR ──────────────────────*/
+static void context_switch(void)
 {
-    asm volatile(
-        "push  r24            \n\t"
-        "in    r24, __SREG__  \n\t"
-        "push  r24            \n\t"
-        ::: "memory");
-
     update_sleep_timers();
     if (--nk_sched.quantum == 0) {
         nk_sched.quantum = NK_QUANTUM_MS;
         switch_to(find_next_task());
     }
+}
 
-    asm volatile(
-        "pop   r24            \n\t"
-        "out   __SREG__, r24  \n\t"
-        "pop   r24            \n\t"
-        "reti                 \n\t"
-        ::: "memory");
+ISR(TIMER0_COMPA_vect)
+{
+    context_switch();
 }


### PR DESCRIPTION
## Summary
- wire up `scheduler_init()` for Timer0 CTC mode at 1 kHz
- expose new `scheduler_run()` entry point
- simplify Timer0 ISR to call `context_switch()`
- document timer setup details
- refine Timer0 reload using compile-time assertion

## Testing
- `meson setup build -Doptimization=s -Dc_std=c2x` *(fails: Assignment target must be an id)*

------
https://chatgpt.com/codex/tasks/task_e_6855e80c18a88331a34e73c06d3a4df3

## Summary by Sourcery

Introduce a 1 kHz scheduler tick using Timer0 in CTC mode and simplify context switching by adding dedicated scheduler_init and scheduler_run APIs, replacing and aliasing existing nk_* entry points.

New Features:
- Add scheduler_init and scheduler_run as public entry points for scheduler setup and start

Enhancements:
- Parameterize Timer0 reload calculation with compile-time assertion to ensure 8-bit range
- Simplify TIMER0_COMPA_vect ISR by extracting context_switch function and removing manual register handling
- Provide alias functions for backward compatibility (nk_init, nk_sched_init, nk_start, nk_sched_run)

Documentation:
- Document Timer0 CTC mode setup and reload details in hardware.rst