### PR TITLE
Fix cross-file defaults and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common apt-transport-https ca-certificates gnupg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/debian-sid-avr.list && \
+    echo "Package: gcc-avr avr-libc binutils-avr\nPin: release o=Debian,a=sid\nPin-Priority: 100" > /etc/apt/preferences.d/90avr-cross && \
+    apt-get update && \
+    apt-get install -y gcc-avr avr-libc binutils-avr avrdude gdb-avr simavr \
+                       qemu-system-misc meson ninja-build doxygen python3-sphinx \
+                       python3-pip graphviz git nodejs npm cloc cscope exuberant-ctags cppcheck && \
+    pip3 install --no-cache-dir breathe exhale sphinx-rtd-theme && \
+    npm install -g prettier && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "avrix-dev",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": ["--cap-add=SYS_PTRACE"],
+    "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+    },
+    "postCreateCommand": "meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross || true"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Configure the Meson build directory for the AVR target
       - name: Configure build
-        run: meson setup build --cross-file cross/avr_m328p.txt
+        run: meson setup build --cross-file cross/atmega328p_gcc14.cross
 
       # Compile all targets using ninja via Meson
       - name: Compile

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ pip3 install --user breathe exhale sphinx-rtd-theme
 npm  install  -g   prettier
 ```
 
+### 2A · VS Code devcontainer
+
+```bash
+code --install-extension ms-vscode.remote-containers
+# then use:  Remote-Containers: Open Folder in Container…
+```
+
+Inside the container run `meson compile -C build` to rebuild after
+changes.
+
+The `postCreateCommand` sets up a `build` directory automatically using
+`cross/atmega328p_gcc14.cross`. Reconfigure with
+`meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross` if
+you change compiler options.
+
 ---
 
 ## 3 · Recommended flags (ATmega328P)
@@ -167,7 +182,7 @@ meson setup build --cross-file cross/atmega328p_gcc14.cross \
 
 1. Fork & branch (`feat/short-title`).
 2. Keep additions **tiny** – flash is precious.
-3. `ninja -C build && meson test` must pass.
+3. `meson compile -C build && meson test` must pass.
 4. Update `docs/monograph.rst` with new flags or memory impact.
 
 ---

--- a/cross/atmega128.cross
+++ b/cross/atmega128.cross
@@ -45,7 +45,7 @@ c_link_args = [
 ]
 
 [built-in options]
-c_std         = 'c23'
+c_std         = 'c2x'
 warning_level = '3'
 werror        = true
 optimization  = 's'

--- a/cross/atmega32.cross
+++ b/cross/atmega32.cross
@@ -58,8 +58,8 @@ c_link_args = [
 # Meson built-in defaults
 # -----------------------------------------------------------------------
 [built-in options]
-c_std            = 'c23'
-optimization     = 'z'
+c_std            = 'c2x'
+optimization     = 's'
 warning_level    = 2
 strip            = true
 default_library  = 'none'

--- a/cross/atmega328p_gcc14.cross
+++ b/cross/atmega328p_gcc14.cross
@@ -44,8 +44,8 @@ c_link_args = [
 ]
 
 [built-in options]
-c_std           = 'c23'
-optimization    = 'z'       # maps to -Oz
+c_std           = 'c2x'
+optimization    = 's'       # maps to -Os
 warning_level   = 2
 strip           = true
 default_library = 'none'
@@ -100,8 +100,8 @@ c_link_args = [
 ]
 
 [built-in options]
-c_std           = 'c23'
-optimization    = 'z'
+c_std           = 'c2x'
+optimization    = 's'
 warning_level   = 2
 strip           = true
 default_library = 'none'

--- a/docs/source/devcontainer.rst
+++ b/docs/source/devcontainer.rst
@@ -1,0 +1,18 @@
+Using the Devcontainer
+======================
+
+The repository ships a ready-made VS Code *devcontainer* for quick
+experimentation.  It provisions the cross tool-chain, Meson, QEMU and
+all documentation helpers.
+
+#. Install the `ms-vscode.remote-containers` extension.
+#. Run ``Remote‑Containers: Open Folder in Container…`` and select this
+   directory.
+#. The container automatically configures a ``build`` directory using
+   ``meson setup build --cross-file cross/atmega328p_gcc14.cross``.
+#. Reconfigure with ``meson setup build --wipe --cross-file
+   cross/atmega328p_gcc14.cross`` when toggling compiler options.
+#. Edit sources, then invoke ``meson compile -C build`` to recompile.
+
+The Docker image mirrors the steps in ``setup.sh`` and therefore
+matches CI precisely.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,3 +22,4 @@ from the build directory to generate HTML output.  These targets may fail if
    monograph
    fuses
    roadmap-qemu-avr
+   devcontainer

--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -181,7 +181,7 @@ User budget        ≥ 18 000  ≥ 1500
 *Meson cross-file* (`cross/atmega328p_gcc14.cross`) encodes the flag set ::
 
    meson setup build --cross-file cross/atmega328p_gcc14.cross
-   ninja -C build
+   meson compile -C build
    qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
 
 FDO cycle ::
@@ -189,7 +189,7 @@ FDO cycle ::
    meson configure build -Dprofile=true   # pass 1 (collect)
    # run workload …
    meson configure build -Dprofile=false  # pass 2 (optimise)
-   ninja -C build
+   meson compile -C build
 
 ----------------------------------------------------------------------
 12 · CI Snapshot
@@ -202,10 +202,10 @@ FDO cycle ::
        runs-on: ubuntu-24.04
        steps:
          - uses: actions/checkout@v4
-         - run: sudo ./setup.sh --modern
-         - run: meson setup build --cross-file cross/atmega328p_gcc14.cross
-         - run: ninja -C build
-         - run: qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic &
+        - run: sudo ./setup.sh --modern
+        - run: meson setup build --cross-file cross/atmega328p_gcc14.cross
+        - run: meson compile -C build
+        - run: qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic &
 
 ----------------------------------------------------------------------
 13 · QEMU Verification

--- a/docs/source/roadmap-qemu-avr.rst
+++ b/docs/source/roadmap-qemu-avr.rst
@@ -36,7 +36,7 @@ For experimental boards or CPU models the upstream GitHub fork
 
    git clone https://github.com/seharris/qemu-avr.git
    cd qemu-avr && ./configure --target-list=avr-softmmu
-   make -j$(nproc) && sudo make install
+   meson compile -C build -j$(nproc) && sudo meson install -C build
 
 3. Bring the tool-chain up to C23
 ---------------------------------
@@ -88,10 +88,10 @@ A minimal CI container is illustrated below:
 
    FROM ubuntu:24.04
    RUN apt update && \
-       apt install -y qemu-system-misc gcc-avr avr-libc make git
+       apt install -y qemu-system-misc gcc-avr avr-libc meson ninja-build git
    COPY . /src
    WORKDIR /src
-   RUN make
+   RUN meson setup build && meson compile -C build
    CMD ["qemu-system-avr", "-M", "mega", "-cpu", "atmega128", \
         "-bios", "unix0.elf", "-nographic"]
 

--- a/meson.build
+++ b/meson.build
@@ -15,9 +15,9 @@ project(
   version          : '0.1.0',
   license          : 'MIT',
   default_options  : [
-    'c_std=c23',
+    'c_std=c2x',
     'warning_level=2',
-    'optimization=z',      # maps to -Oz
+    'optimization=s',      # Meson 1.3 accepts "s" for -Os
     'buildtype=release'
   ]
 )
@@ -29,7 +29,6 @@ else
 endif
 
 subdir('src')
-subdir('lib')
 subdir('examples')
 subdir('tests')
 

--- a/setup.sh
+++ b/setup.sh
@@ -93,7 +93,8 @@ if ! qemu-system-avr -version &>/dev/null; then
                        libpixman-1-dev libgtk-3-dev
   git clone --depth 1 https://github.com/seharris/qemu-avr /opt/qemu-avr
   ( cd /opt/qemu-avr && ./configure --target-list=avr-softmmu --disable-werror \
-        >/dev/null && make -s -j"$(nproc)" && make install )
+        >/dev/null && meson compile -C build -j"$(nproc)" >/dev/null \
+        && meson install -C build >/dev/null )
 fi
 
 #──────────────── 4. print tool versions ──────────────────────────────────
@@ -116,7 +117,7 @@ echo "  export LDFLAGS=\"$LDFLAGS\""
 if [[ -f cross/atmega328p_gcc14.cross ]]; then
   echo "[info] Configuring Meson build …"
   meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross >/dev/null
-  ninja -C build >/dev/null
+  meson compile -C build >/dev/null
   ELF=$(find build -name '*.elf' | head -1)
   echo "[info] Built firmware: $ELF"
   echo "[info] Launching QEMU (arduino-uno, head-less) …"

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,8 +32,12 @@ portable_src = files(   # no <avr/...>
   'fs.c'
 )
 
-avr_only_src = kernel_src + []
-avr_only_src -= portable_src       # diff yields AVR-specific set
+avr_only_src = []
+foreach f : kernel_src
+  if not portable_src.contains(f)
+    avr_only_src += f
+  endif
+endforeach
 
 # ───────────────────────── 2. libavrix / libavrix_host ───────────────
 if meson.is_cross_build()          # ==> target = AVR


### PR DESCRIPTION
## Summary
- clean up Meson options for compatibility
- rename cross profile to `atmega328p_gcc14.cross`
- keep devcontainer synced with docs
- drop obsolete `lib` subdir
- refine Meson source lists

## Testing
- `meson setup build --wipe`
- `meson compile -C build` *(fails: cross build not configured, syntax check error)*
- `meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross` *(fails: Malformed machine file)*

------
https://chatgpt.com/codex/tasks/task_e_6855e866ee64833194ab09fb2f44dae3

## Summary by Sourcery

Add VS Code devcontainer support, standardize AVR cross-file naming and Meson options, streamline build commands, and update CI and documentation accordingly.

New Features:
- Introduce VS Code devcontainer setup with Dockerfile, devcontainer.json, and documentation

Enhancements:
- Rename AVR cross profile to cross/atmega328p_gcc14.cross in scripts, CI, and docs
- Update Meson default options (use c2x standard and 's' optimization) and refine AVR source list logic
- Replace ninja commands with `meson compile` in setup scripts, CI, and documentation
- Remove obsolete `lib` subdirectory from Meson build configuration

CI:
- Update GitHub Actions workflow to use the new cross/atmega328p_gcc14.cross file

Documentation:
- Sync README and monograph docs to include devcontainer instructions and updated build commands
- Add devcontainer.rst to document container-based development workflow