### PR TITLE
Update fuses docs

### DIFF
--- a/docs/source/fuses.rst
+++ b/docs/source/fuses.rst
@@ -44,3 +44,25 @@ Program the 328P with:
            -U efuse:w:0x05:m
 
 Adjust ``0xD5`` if you select a different brown-out threshold.
+
+Reading and verifying fuses with avrdude
+---------------------------------------
+
+Before modifying anything, dump the current fuse and lock bytes:
+
+.. code-block:: bash
+
+   avrdude -c avrisp -p m328p \
+           -U lfuse:r:-:i \
+           -U hfuse:r:-:i \
+           -U efuse:r:-:i \
+           -U lock:r:-:i
+
+The last value reports the lock bits.  After programming, read back the
+lock byte to confirm it equals ``0x0F``:
+
+.. code-block:: bash
+
+   avrdude -c avrisp -p m328p -U lock:r:-:i
+
+This verifies that the boot section is protected.


### PR DESCRIPTION
## Summary
- document how to read and verify fuse and lock bits using `avrdude`

## Testing
- `meson setup build --wipe -Doptimization=s -Dc_std=c2x` *(fails: Assignment target must be an id)*
- `ninja -C build` *(fails: no build.ninja)*
- `meson test -C build` *(fails: no build data file)*

------
https://chatgpt.com/codex/tasks/task_e_6855e894e590833181798f0905f1044e