### PR TITLE
Door RPC improvements

### DIFF
--- a/docs/source/monograph.rst
+++ b/docs/source/monograph.rst
@@ -100,8 +100,20 @@ Wear-levelled, power-fail-safe log:
 6 · Descriptor-Based RPC (“Doors”)
 ----------------------------------------------------------------------
 
-* 4 door descriptors per task in ``.noinit``.  
+* 4 door descriptors per task in ``.noinit``.
 * 128-byte shared slab (16 Cap’n-Proto words) → zero-copy.
+* ``door_vec`` vectors are initialised by ``nk_init`` for every task.
+
+Call path ::
+
+   ``door_call`` records the caller’s TID, payload length and flags
+   before invoking ``_nk_door``.  This assembly helper copies the
+   request into ``door_slab``, performs a stack switch to the callee and
+   returns once ``door_return`` is executed.  The caller then copies the
+   reply from the slab.
+
+CapnDoorSynthesis  binds the slab layout directly to Cap’n-Proto schemas
+allowing minimal marshalling overhead.
 
 ===============  ========================  Flash  SRAM  Latency (µs)
 Primitive        Foot-print

--- a/src/door.c
+++ b/src/door.c
@@ -27,12 +27,14 @@ _Static_assert(sizeof(door_t)  == 2,    "door_t must remain 2 bytes");
 uint8_t door_slab[DOOR_SLAB_SIZE]
         __attribute__((section(".noinit")));               /* shared payload */
 
-door_t door_vec[NK_MAX_TASKS][DOOR_SLOTS]
-        __attribute__((section(".noinit")));               /* per-task table */
+extern door_t door_vec[NK_MAX_TASKS][DOOR_SLOTS];          /* per-task table */
 
 static volatile uint8_t door_caller  __attribute__((section(".noinit")));
 static volatile uint8_t door_words_v;   /* 1-15 words  (8-byte each) */
 static volatile uint8_t door_flags_v;   /* low 4 bits */
+
+/* ASM trampoline -----------------------------------------------------*/
+extern void _nk_door(const void *buf, uint8_t nbytes, uint8_t tgt_tid);
 
 /*───────────────── 2. CRC-8 (Dallas/Maxim, 0x31 poly) ──────────────*/
 static uint8_t crc8_maxim(const uint8_t *p, uint8_t len)
@@ -79,16 +81,21 @@ void door_call(uint8_t idx, const void *buf)        /* caller side */
     if (d.words == 0) return;                 /* descriptor empty */
 
     const uint8_t nbytes = (uint8_t)(d.words * 8);
-    memcpy(door_slab, buf, nbytes);           /* → request slab */
+    const void   *src    = buf;
+    uint8_t       len    = nbytes;
 
-    if (d.flags & 0x01)                       /* CRC flag bit 0 */
+    if (d.flags & 0x01) {                     /* CRC flag bit 0 */
+        memcpy(door_slab, buf, nbytes);
         door_slab[nbytes] = crc8_maxim(door_slab, nbytes);
+        src = door_slab;
+        ++len;
+    }
 
     door_caller  = caller;
     door_words_v = d.words;
     door_flags_v = d.flags;
 
-    nk_switch_to(d.tgt_tid);                  /* ↔ callee */
+    _nk_door(src, len, d.tgt_tid);            /* ↔ callee */
 
     memcpy((void *)buf, door_slab, nbytes);   /* ← reply */
 }

--- a/src/door_entry.S
+++ b/src/door_entry.S
@@ -1,0 +1,36 @@
+#include <avr/io.h>
+#include "door.h"
+#include "nk_task.h"
+
+.section .text
+.global _nk_door
+.type _nk_door, @function
+
+; void _nk_door(const uint8_t *src, uint8_t len, uint8_t tid)
+; r24:r25 -> src pointer
+; r22     -> len (bytes)
+; r20     -> target tid
+_nk_door:
+    push r28
+    push r29
+
+    movw r30, r24        ; Z = src
+    ldi  r28, lo8(door_slab)
+    ldi  r29, hi8(door_slab)
+    mov  r18, r22        ; byte counter
+1:
+    cpi  r18, 0
+    breq 2f
+    ld   r19, Z+
+    st   Y+, r19
+    dec  r18
+    rjmp 1b
+2:
+    mov  r24, r20        ; nk_switch_to parameter
+    rcall nk_switch_to
+
+    pop  r29
+    pop  r28
+    ret
+
+.size _nk_door, .-_nk_door

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,7 +25,8 @@ kernel_src = files(
   'nk_fs.c',
   'kalloc.c',
   'context_switch.S',  # hand-written AVR ASM
-  'switch_task.S'
+  'switch_task.S',
+  'door_entry.S'
 )
 
 portable_src = files(   # no <avr/...>
@@ -37,7 +38,8 @@ avr_only_src = files(
   'door.c',
   'task.c',
   'nk_fs.c',
-  'kalloc.c'
+  'kalloc.c',
+  'door_entry.S'
 )
 
 # ───────────────────────── 2. libavrix / libavrix_host ───────────────

--- a/src/task.c
+++ b/src/task.c
@@ -33,8 +33,9 @@ static struct {
     .quantum = NK_QUANTUM_MS
 };
 
-/* Door RPC descriptors (defined in door.c) ----------------------*/
-extern door_t door_vec[NK_MAX_TASKS][DOOR_SLOTS];
+/* Door RPC descriptors (one vector per task) ---------------------*/
+door_t door_vec[NK_MAX_TASKS][DOOR_SLOTS]
+    __attribute__((section(".noinit")));
 
 /* Optional guarded stacks ---------------------------------------*/
 #if NK_OPT_STACK_GUARD
@@ -144,6 +145,9 @@ static inline void atomic_schedule(void)
 
 void nk_init(void)
 {
+#if DOOR_SLOTS > 0
+    memset(door_vec, 0, sizeof(door_vec));
+#endif
 #if NK_OPT_STACK_GUARD
     for (nk_stack_t *s = nk_stacks; s < nk_stacks + NK_MAX_TASKS; ++s) {
         s->guard_lo = STACK_GUARD_PATTERN;
@@ -186,6 +190,10 @@ bool nk_task_create(nk_tcb_t *tcb,
         .deps        = 0,
         .sleep_ticks = 0
     };
+
+#if DOOR_SLOTS > 0
+    memset(door_vec[nk_sched.count], 0, sizeof(door_vec[0]));
+#endif
 
     cli();
     nk_sched.tasks[nk_sched.count++] = tcb;


### PR DESCRIPTION
## Summary
- document full door call and CapnDoorSynthesis path
- use `_nk_door` trampoline to copy door payload and switch tasks
- minimise assembly helper and copy request on entry
- clear door vectors when tasks are created

## Testing
- `python3 tests/check_docs.py`
- `meson compile -C build` *(fails to compile spin_test)*
- `meson test -C build` *(fails to compile spin_test)*

------
https://chatgpt.com/codex/tasks/task_e_6855ed7efd008331b3324eead7b41952