### PR TITLE
Configure CI with modern+legacy matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # --modern ⇒ gcc-avr 14.x   + full tool-set + docs + QEMU test
-        # --legacy ⇒ gcc-avr 7.3.x  (compiler only)      (*docs still build*)
-        mode: ["--modern", "--legacy"]
+        # Matrix defines the configuration style for the AVR tool-chain
+        #   modern ⇒ gcc-avr 14.x + complete tooling (QEMU, docs, etc.)
+        #   legacy ⇒ gcc-avr 7.3.x only; documentation still builds
+        config: [modern, legacy]
 
     steps:
       # 0.  Source checkout ------------------------------------------------
@@ -44,15 +45,15 @@ jobs:
           fetch-depth: 1
 
       # 1.  Install complete AVR environment ------------------------------
-      - name: Run setup.sh (${{ matrix.mode }})
-        run: sudo ./setup.sh ${{ matrix.mode }}
+      - name: Run setup.sh (${{ matrix.config }})
+        run: sudo ./setup.sh --${{ matrix.config }}
 
       # 2.  Configure cross-build  ----------------------------------------
       #     Legacy build needs C11; modern stays on C23.
       - name: Meson setup (cross)
         run: |
           EXTRA_OPT=""
-          if [[ "${{ matrix.mode }}" == "--legacy" ]]; then
+          if [[ "${{ matrix.config }}" == "legacy" ]]; then
             EXTRA_OPT="-Dc_std=c11"
           fi
           meson setup build \
@@ -77,7 +78,7 @@ jobs:
       - name: Upload firmware (ELF + HEX)
         uses: actions/upload-artifact@v4
         with:
-          name: avrix-firmware-${{ matrix.mode }}
+          name: avrix-firmware-${{ matrix.config }}
           path: |
             build/**/unix0.elf
             build/**/unix0.hex
@@ -86,7 +87,7 @@ jobs:
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
-          name: docs-${{ matrix.mode }}
+          name: docs-${{ matrix.config }}
           path: |
             build/docs           # Sphinx output
             build/doxygen/html   # Doxygen HTML


### PR DESCRIPTION
## Summary
- create a `config` job matrix to differentiate modern and legacy setups
- run `setup.sh` with `--<config>` for each matrix entry
- keep existing build, test and docs steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f9d0da248331876d4fab25ce964b