### PR TITLE
Enhance doc checker and add tests

### DIFF
--- a/tests/test_check_docs_parser.py
+++ b/tests/test_check_docs_parser.py
@@ -1,0 +1,107 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "check_docs", Path(__file__).resolve().parent / "check_docs.py"
+)
+check_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_docs)
+
+
+def test_no_toctree_blocks(tmp_path):
+    index = tmp_path / "index.rst"
+    index.write_text("Just text\nAnother line\n", encoding="utf-8")
+    assert check_docs.parse_references(index) == []
+
+
+def test_multiple_toctree_blocks(tmp_path):
+    index = tmp_path / "index.rst"
+    index.write_text(
+        """
+Intro
+
+.. toctree::
+   first
+   second
+
+.. toctree::
+   third
+""",
+        encoding="utf-8",
+    )
+    assert check_docs.parse_references(index) == ["first", "second", "third"]
+
+
+def test_directive_options_ignored(tmp_path):
+    index = tmp_path / "index.rst"
+    index.write_text(
+        """
+.. toctree::
+   :maxdepth: 2
+   :caption: Example
+
+   page1
+   page2
+""",
+        encoding="utf-8",
+    )
+    assert check_docs.parse_references(index) == ["page1", "page2"]
+
+
+def test_references_with_and_without_rst_extension(tmp_path):
+    docs_dir = tmp_path
+    (docs_dir / "page1.rst").write_text("", encoding="utf-8")
+    (docs_dir / "page2.rst").write_text("", encoding="utf-8")
+    index = docs_dir / "index.rst"
+    index.write_text(
+        """
+.. toctree::
+   page1
+   page2.rst
+""",
+        encoding="utf-8",
+    )
+    refs = check_docs.parse_references(index)
+    assert refs == ["page1", "page2.rst"]
+    assert check_docs.check_references(refs, docs_dir=docs_dir) == []
+
+
+def test_missing_vs_existing_files(tmp_path):
+    docs_dir = tmp_path
+    (docs_dir / "existing.rst").write_text("", encoding="utf-8")
+    index = docs_dir / "index.rst"
+    index.write_text(
+        """
+.. toctree::
+   existing
+   missing
+""",
+        encoding="utf-8",
+    )
+    refs = check_docs.parse_references(index)
+    missing = check_docs.check_references(refs, docs_dir=docs_dir)
+    assert missing == [docs_dir / "missing.rst"]
+
+
+def test_recursive_parsing(tmp_path):
+    docs_dir = tmp_path
+    sub = docs_dir / "sub.rst"
+    sub.write_text(
+        """
+.. toctree::
+   child
+""",
+        encoding="utf-8",
+    )
+    (docs_dir / "child.rst").write_text("", encoding="utf-8")
+    index = docs_dir / "index.rst"
+    index.write_text(
+        """
+.. toctree::
+   sub
+""",
+        encoding="utf-8",
+    )
+    refs = check_docs.parse_references(index, recursive=True)
+    assert refs == ["sub", "child"]
+


### PR DESCRIPTION
## Summary
- allow overriding documentation directory and index file via CLI
- optionally parse referenced pages recursively
- add pytest coverage for toctree parsing and reference checking

## Testing
- `pytest tests/test_check_docs_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f9dba8848331883a92e94c28c8ac