### PR TITLE
Remove leftover nk_task symlink creation

### DIFF
--- a/optimize.sh
+++ b/optimize.sh
@@ -10,7 +10,6 @@
 set -euo pipefail
 MCU=${MCU:-atmega328p}
 AVR_INC=$(realpath $(avr-gcc -print-file-name=include)/../../../../avr/include)
-[[ -e include/nk_task.h ]] || { ln -s task.h include/nk_task.h; trap 'rm -f include/nk_task.h' EXIT; }
 for f in src/*.c; do
   echo "[info] clang-tidy $f"
   clang-tidy "$f" --quiet \


### PR DESCRIPTION
## Summary
- drop stale symlink setup from `optimize.sh`

## Testing
- `meson setup build -Dc_std=c2x` *(fails: Unknown C std 'c23' with default options)*
- `ninja -C build` *(fails: build stopped due to compile error)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9e931508331a13f7ca56c22a40b