### PR TITLE
Improve setup reliability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,12 @@
 
 FROM ubuntu:24.04
 
-RUN apt-get -qq update && \
-    apt-get -yqq install --no-install-recommends \
+RUN apt-get -qq update
+RUN apt-get -yqq install --no-install-recommends \
         gcc-avr avr-libc binutils-avr qemu-system-misc \
         meson ninja-build make git ca-certificates \
-        python3-pip && \
-    rm -rf /var/lib/apt/lists/*
+        python3-pip
+RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /avrix
 COPY . /avrix

--- a/setup.sh
+++ b/setup.sh
@@ -57,16 +57,24 @@ Package: gcc-avr avr-libc binutils-avr
 Pin: release o=Debian,a=sid
 Pin-Priority: 100
 EOF
+    if ! have_repo "deb.debian.org/debian sid"; then
+      echo "[error] failed to add sid repo; falling back to legacy toolchain" >&2
+      MODE="--legacy"
+    fi
   fi
 else
   add-apt-repository -y universe
+  if ! have_repo "universe"; then
+    echo "[error] failed to add 'universe' repo; falling back to legacy toolchain" >&2
+    MODE="--legacy"
+  fi
 fi
 apt-get -qq update
 
 # ───────────────────────── 2 · packages ─────────────────────────────────
-TOOLCHAIN=gcc-avr   # will resolve to 14.x (sid) or 7.3 (ubuntu)
+TOOLCHAIN_PKG=gcc-avr   # will resolve to 14.x (sid) or 7.3 (ubuntu)
 BASE_PKGS=(
-  "$TOOLCHAIN" avr-libc binutils-avr avrdude gdb-avr
+  "$TOOLCHAIN_PKG" avr-libc binutils-avr avrdude gdb-avr
   qemu-system-misc  simavr
 )
 


### PR DESCRIPTION
## Summary
- verify repository addition in setup script
- rename `TOOLCHAIN` variable to `TOOLCHAIN_PKG`
- split apt update/install steps in Dockerfile

## Testing
- `python3 tests/check_docs.py` *(fails: missing docs)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9fffa6c8331b4ef3d6fe9116a76

## Summary by Sourcery

Improve reliability of environment setup by verifying apt repository additions with fallbacks, renaming the toolchain variable for clarity, and splitting Dockerfile apt commands.

Enhancements:
- Verify addition of 'sid' and 'universe' apt repositories in setup script and fallback to legacy toolchain on failure
- Rename TOOLCHAIN variable to TOOLCHAIN_PKG for clarity
- Split apt-get update and install into separate Dockerfile commands for better caching and readability