### PR TITLE
Fix initial slock ownership in lattice mode

### DIFF
--- a/include/nk_lock.h
+++ b/include/nk_lock.h
@@ -96,7 +96,8 @@ static inline void nk_slock_init(nk_slock_t *s)
 {
     nk_flock_init(&s->base);
 #   if NK_ENABLE_LATTICE
-    s->owner = 0;
+    /* initial ticket so the first waiter wins immediately */
+    s->owner = NK_LATTICE_STEP;
 #   endif
 }
 


### PR DESCRIPTION
## Summary
- ensure `nk_slock_init` grants the first lattice ticket
- document the reason for the initial ticket

## Testing
- `gcc -DNK_ENABLE_LATTICE=1 -I. /tmp/test_lock.c -o /tmp/test_lock && /tmp/test_lock`

------
https://chatgpt.com/codex/tasks/task_e_6856024540f88331a9249e570fc79a27

## Summary by Sourcery

Fix initial spinlock ownership in lattice mode to grant the first waiter the initial ticket immediately and document the rationale

Bug Fixes:
- Set the initial owner to NK_LATTICE_STEP in nk_slock_init to ensure the first waiter acquires the lock immediately in lattice mode

Enhancements:
- Add a comment explaining the reason for the initial lattice ticket assignment