### PR TITLE
Add UTF-8 headers and fix docs checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# µ-UNIX for AVR  
+<!-- coding: utf-8 -->
+# µ-UNIX for AVR
 *A ≤ 10 kB C23 nanokernel, wear-levelled log-FS, and lock/RPC suite for the Arduino Uno R3.*
 
 **Quick hardware summary**

--- a/include/nk_lock.h
+++ b/include/nk_lock.h
@@ -15,6 +15,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* Feature toggles: default to disabled unless specified by build system */
+#ifndef NK_ENABLE_QLOCK
+#  define NK_ENABLE_QLOCK 0
+#endif
+#ifndef NK_ENABLE_LATTICE
+#  define NK_ENABLE_LATTICE 0
+#endif
+#ifndef NK_ENABLE_DAG
+#  define NK_ENABLE_DAG 0
+#endif
+
 /*--------------------------------------------------------------*
  * 0.  Build-time detection
  *--------------------------------------------------------------*/


### PR DESCRIPTION
## Summary
- add `coding: utf-8` comment to README to clarify encoding
- restore `tests/check_docs.py` as a runnable script
- keep backward-compatible `DOCS_DIR` and parameter defaults
- ensure default feature toggles for locks are defined in `nk_lock.h`

## Testing
- `pytest -q tests/test_check_docs.py tests/test_check_docs_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_68560243ca688331a7e15d0dd9eed2d2

## Summary by Sourcery

Restore and enhance the documentation checker script, clarify README encoding, and introduce default lock feature toggles.

Bug Fixes:
- Restore and fix tests/check_docs.py script to run as a CLI tool and correctly detect missing Sphinx toctree references.

Enhancements:
- Simplify toctree parsing in the docs checker with recursive traversal and a unified parse function.
- Add backward-compatible DOCS_DIR alias and default index-file support in the docs checker.
- Define default build-time feature toggles (NK_ENABLE_QLOCK, NK_ENABLE_LATTICE, NK_ENABLE_DAG) in nk_lock.h.

Documentation:
- Add a UTF-8 encoding declaration header to README.md.