### PR TITLE
Refactor package install logic

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -44,8 +44,20 @@ case "$MODE" in --modern|--legacy|"") ;; *)
 esac
 
 step() { printf '\n\033[1;36m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
-pkg_installed() { dpkg -s "$1" &>/dev/null; }
 have_repo()     { grep -RHq "$1" /etc/apt/*sources* 2>/dev/null; }
+
+# Base toolchain packages installed in both modes
+TOOLCHAIN_PKG=gcc-avr
+BASE_PKGS=(
+  "$TOOLCHAIN_PKG" avr-libc binutils-avr avrdude gdb-avr
+  qemu-system-misc simavr
+)
+
+# Extra utilities installed only in modern mode
+EXTRA_PKGS=(
+  meson ninja-build doxygen python3-sphinx python3-pip python3-venv
+  cloc cscope exuberant-ctags cppcheck graphviz nodejs npm
+)
 
 step "Selected mode: $MODE"
 
@@ -83,23 +95,12 @@ fi
 apt-get -qq update
 
 # ───────────────────────── 2 · packages ─────────────────────────────────
-TOOLCHAIN_PKG=gcc-avr   # will resolve to 14.x (sid) or 7.3 (ubuntu)
-BASE_PKGS=(
-  "$TOOLCHAIN_PKG" avr-libc binutils-avr avrdude gdb-avr
-  qemu-system-misc  simavr
-)
+PACKAGES=("${BASE_PKGS[@]}")
+[[ $MODE == "--modern" ]] && PACKAGES+=("${EXTRA_PKGS[@]}")
 
-if [[ $MODE == "--modern" ]]; then
-  BASE_PKGS+=(
-    meson ninja-build doxygen python3-sphinx python3-pip python3-venv
-    cloc cscope exuberant-ctags cppcheck graphviz nodejs npm
-  )
-fi
-
-step "Installing ${#BASE_PKGS[@]} packages (this can take a while)"
-for p in "${BASE_PKGS[@]}"; do
-  pkg_installed "$p" || apt-get -yqq install "$p"
-done
+step "Installing ${#PACKAGES[@]} packages (this can take a while)"
+apt-get -qq update
+apt-get -yqq install "${PACKAGES[@]}"
 
 # ───────────────────────── 3 · docs venv (modern) ───────────────────────
 if [[ $MODE == "--modern" ]]; then


### PR DESCRIPTION
## Summary
- predefine base and extra package lists near the top of `setup.sh`
- consolidate package installation into a single `apt-get` call
- refresh apt indices right before install

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856024670648331a9ba33ebe62c9b96