### PR TITLE
Enhance doc reference checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 docs/build/
 docs/doxygen/
 docker/avrix.img
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- coding: utf-8 -->
 ````markdown
 # Avrix: µ-UNIX for AVR 🍋  
 **Project codename:** **Avrix** (styled as **AVR-unIX**).

--- a/tests/test_check_docs_cli.py
+++ b/tests/test_check_docs_cli.py
@@ -1,0 +1,10 @@
+import check_docs
+from pathlib import Path
+
+
+def test_main_missing_index(tmp_path, capsys):
+    idx = tmp_path / "missing.rst"
+    ret = check_docs.main(["--index-file", str(idx)])
+    captured = capsys.readouterr()
+    assert ret == 2
+    assert "Index file not found" in captured.err

--- a/tests/test_check_docs_parser.py
+++ b/tests/test_check_docs_parser.py
@@ -105,3 +105,21 @@ def test_recursive_parsing(tmp_path):
     refs = check_docs.parse_references(index, recursive=True)
     assert refs == ["sub", "child"]
 
+
+def test_allowed_extensions(tmp_path):
+    docs_dir = tmp_path
+    (docs_dir / "page.md").write_text("", encoding="utf-8")
+    index = docs_dir / "index.rst"
+    index.write_text(
+        """
+.. toctree::
+   page
+""",
+        encoding="utf-8",
+    )
+    refs = check_docs.parse_references(index, allowed_exts=(".rst", ".md"))
+    assert refs == ["page"]
+    missing = check_docs.check_references(
+        refs, docs_dir=docs_dir, allowed_exts=(".rst", ".md")
+    )
+    assert missing == []


### PR DESCRIPTION
## Summary
- clean up encoding comment in README
- expand `check_docs.py` to handle multiple extensions
- add index file existence check
- ignore `__pycache__` in Git
- extend tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560757d2e88331bcb2dc0359654fc7