### PR TITLE
Add Meson flash helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Legacy build? Replace `-std=c23` with `-std=c11` and drop the two GCC-14 extras.
 meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross
 meson compile -C build
 qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
+meson compile -C build flash           # flash over /dev/ttyACM0
 ```
 
 For LLVM: use `cross/atmega328p_clang20.cross`.
@@ -215,7 +216,7 @@ The container compiles the firmware, emits `avrix.img`, then boots QEMU.
 
 | Gap                                       | Why it matters                                 | Proposed fix                                        |
 | ----------------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
-| **Real-board flash script**               | newcomers still need the `avrdude` incantation | add `scripts/flash.sh` → auto-detect `/dev/ttyACM*` |
+| **Real-board flash helper**               | newcomers still need the `avrdude` incantation | `meson compile -C build flash` flashes the Uno |
 | **tmux-dev launcher**                     | 4-pane session exists only in docs             | ship `scripts/tmux-dev.sh`                          |
 | **On-device GDB stub**                    | “printf + LED” is clumsy                       | gate tiny `avr-gdbstub` behind `-DDEBUG_GDB`        |
 | **Static-analysis CI**                    | cppcheck runs locally only                     | add `cppcheck/clang-tidy` GitHub job                |

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -158,6 +158,8 @@ For a *legacy* build drop ``--icf`` / ``-fipa-pta`` and switch
         --cross-file cross/atmega328p_gcc14.cross -Dc_std=c23
    meson compile -C build
    qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
+   meson compile -C build flash \
+        -Dflash_port=/dev/ttyACM0 -Dflash_programmer=arduino
 
 ``cross/atmega328p_clang20.cross`` is provided for LLVM 20 users.
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,7 @@
 option('avr_inc_dir', type: 'string', value: '',
        description: 'Path to AVR libc headers (fallback to standard locations)')
+
+option('flash_port', type: 'string', value: '/dev/ttyACM0',
+       description: 'Serial device for avrdude')
+option('flash_programmer', type: 'string', value: 'arduino',
+       description: 'Programmer string for avrdude')

--- a/src/meson.build
+++ b/src/meson.build
@@ -92,3 +92,38 @@ install_headers(
   '../include/nk_superlock.h',
   subdir : 'avrix'
 )
+
+# ───────────────────────── 5. Flash helper  ───────────────────────────
+# The kernel itself is a static library.  For convenience, convert the
+# demo ELF to Intel HEX and invoke ``avrdude``.  This target is gated by
+# a cross build and requires ``avr-objcopy`` / ``avrdude`` to be present.
+
+if meson.is_cross_build()
+  objcopy = find_program('avr-objcopy', required: false)
+  avrdude = find_program('avrdude', required: false)
+
+  if objcopy.found() and avrdude.found()
+    demo_elf = meson.project_build_root() / 'unix0.elf'
+
+    hex_out = custom_target(
+      'firmware_hex',
+      input  : demo_elf,
+      output : 'firmware.hex',
+      command: [objcopy, '-O', 'ihex', '@INPUT@', '@OUTPUT@']
+    )
+
+    custom_target(
+      'flash',
+      input  : hex_out,
+      output : 'flash.stamp',
+      command: [
+        avrdude,
+        '-c', get_option('flash_programmer'),
+        '-p', 'm328p',
+        '-P', get_option('flash_port'),
+        '-U', 'flash:w:@INPUT@'
+      ],
+      console : true
+    )
+  endif
+endif


### PR DESCRIPTION
## Summary
- expose flash port/programmer Meson options
- add a cross-flash target in `src/meson.build`
- describe the new command in README and toolchain.rst
- update gap table entry

## Testing
- `meson setup build --wipe` *(fails: Tried to form an absolute path to a dir in the source tree)*

------
https://chatgpt.com/codex/tasks/task_e_685616024b488331a0dcfd547dbff065