### PR TITLE
Implement fs_list/unlink APIs with test

### DIFF
--- a/include/fs.h
+++ b/include/fs.h
@@ -47,13 +47,7 @@ int  fs_open(const char *name, file_t *f);
 int  fs_write(file_t *f, const void *buf, uint16_t len);
 int  fs_read(file_t *f, void *buf, uint16_t len);
 /**
- * List all valid filenames in the flat directory.
- *
- * \param[out] out  Array with ``FS_NUM_INODES`` elements for storing names.
- * \return          Number of entries copied into ``out``.
- */
-/**
- * Populate *buf* with a newline separated list of valid filenames.
+ * Populate *buf* with a newline-separated list of valid filenames.
  *
  * The resulting string is always NUL terminated.  Names exceeding
  * ``len`` are truncated to fit.  The directory is flat so at most

--- a/tests/fs_roundtrip.c
+++ b/tests/fs_roundtrip.c
@@ -1,0 +1,49 @@
+#include "fs.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+int main(void)
+{
+    fs_init();
+
+    /* reserve block zero */
+    int dummy = fs_create("dummy", 1);
+    file_t d;
+    assert(fs_open("dummy", &d) == 0);
+    char c = 'x';
+    assert(fs_write(&d, &c, 1) == 1);
+
+    /* create and write to a file */
+    int inum = fs_create("demo", 1);
+    assert(inum >= 0);
+
+    file_t fh;
+    assert(fs_open("demo", &fh) == 0);
+
+    const char msg[] = "sample";
+    assert(fs_write(&fh, msg, sizeof msg) == (int)sizeof msg);
+
+    fh.off = 0;
+    char buf[sizeof msg];
+    int n = fs_read(&fh, buf, sizeof buf);
+    printf("read %d\n", n);
+    assert(n == (int)sizeof buf);
+    assert(memcmp(buf, msg, sizeof msg) == 0);
+
+    char list[64];
+    int cnt = fs_list(list, sizeof list);
+    printf("list before unlink (%d): %s\n", cnt, list);
+    assert(strstr(list, "demo") != NULL);
+
+    assert(fs_unlink("demo") == 0);
+    assert(fs_open("demo", &fh) == -1);
+
+    char list2[64];
+    int cnt2 = fs_list(list2, sizeof list2);
+    printf("list after unlink (%d): %s\n", cnt2, list2);
+    assert(strstr(list2, "demo") == NULL);
+
+    puts("fs roundtrip passed");
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,7 +33,7 @@ fsmod       = import('fs')
 inc_list    = [inc]                       # base include dir from root
 if host_machine.cpu_family() != 'avr'
   # Host builds use stub AVR headers located in compat/avr
-  inc_list += include_directories(meson.project_source_root() / 'compat')
+  inc_list += include_directories('../compat')
 endif
 avr_opt_dir = get_option('avr_inc_dir')   # optional – user override
 
@@ -91,6 +91,7 @@ flock_src    = ['flock_stress.c', 'sim.c'] + extra_src
 spin_src     = ['spin_test.c', 'sim.c'] + extra_src
 romfs_src    = ['romfs_test.c', 'sim.c'] + extra_src
 superlock_src = ['superlock_test.c', 'sim.c'] + extra_src
+roundtrip_src = ['fs_roundtrip.c', 'sim.c'] + extra_src
 
 if native_mode
   fs_exe = executable(
@@ -133,6 +134,14 @@ if native_mode
     c_args              : common_cflags,
     native              : true
   )
+  roundtrip_exe = executable(
+    'fs_roundtrip',
+    roundtrip_src,
+    link_with           : libfs,
+    include_directories : inc_list,
+    c_args              : common_cflags,
+    native              : true
+  )
 else
   fs_exe = executable(
     'fs_test',
@@ -169,6 +178,13 @@ else
     include_directories : inc_list,
     c_args              : common_cflags
   )
+  roundtrip_exe = executable(
+    'fs_roundtrip',
+    ['fs_roundtrip.c', meson.project_source_root() / 'src/fs.c'] + extra_src,
+    link_with           : libavrix,
+    include_directories : inc_list,
+    c_args              : common_cflags
+  )
 endif
 
 test('fs_basic',    fs_exe)
@@ -176,3 +192,4 @@ test('flock_stress', flock_exe)
 test('spin_lock',    spin_exe)
 test('superlock_basic', superlock_exe)
 test('romfs_basic',  romfs_exe)
+test('fs_roundtrip', roundtrip_exe)


### PR DESCRIPTION
## Summary
- document fs_list and fs_unlink in fs.h
- provide a new roundtrip test covering create/read/write/list/unlink
- hook the test in meson.build

## Testing
- `meson setup build --wipe`
- `ninja -C build`
- `meson test -C build` *(fails: romfs_basic SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_685615fa928c8331827f708b491c0402