### PR TITLE
Add simavr filesystem test and extend fixed-point coverage

### DIFF
--- a/tests/fs_simavr_basic.c
+++ b/tests/fs_simavr_basic.c
@@ -1,0 +1,34 @@
+#include "fs.h"
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+int main(void)
+{
+    fs_init();
+
+    /* create a file and write to it */
+    assert(fs_create("a.txt", 1) >= 0);
+    file_t f;
+    assert(fs_open("a.txt", &f) == 0);
+    const char msg[] = "simavr";
+    assert(fs_write(&f, msg, strlen(msg)) == (int)strlen(msg));
+
+    /* read it back */
+    f.off = 0;
+    char buf[8] = {0};
+    assert(fs_read(&f, buf, sizeof buf - 1) == (int)strlen(msg));
+    printf("read:%s\n", buf);
+
+    /* list files */
+    char list[32] = {0};
+    int n = fs_list(list, sizeof list);
+    printf("list:%d:%s\n", n, list);
+
+    /* remove and confirm */
+    assert(fs_unlink("a.txt") == 0);
+    assert(fs_open("a.txt", &f) != 0);
+
+    puts("fs simavr ok");
+    return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,8 +54,11 @@ endif
 
 common_cflags = [
   '-O2', '-Wall', '-Wextra', '-pedantic',
-  '-std=c17',                # host compiler, C23 not required
-  '-march=native'
+  '-std=c17'
+]
+avr_cflags = [
+  '-Os', '-Wall', '-Wextra', '-pedantic',
+  '-std=c11'
 ]
 
 # Convenience: TRUE when tests *must* be compiled for the host
@@ -176,3 +179,19 @@ test('flock_stress', flock_exe)
 test('spin_lock',    spin_exe)
 test('superlock_basic', superlock_exe)
 test('romfs_basic',  romfs_exe)
+
+simavr = find_program('simavr', required : false)
+if simavr.found() and meson.is_cross_build()
+  fs_simavr_exe = executable(
+    'fs_simavr_basic',
+    ['fs_simavr_basic.c', meson.project_source_root() / 'src/fs.c'],
+    include_directories : inc_list,
+    c_args              : avr_cflags
+  )
+  test(
+    'fs_simavr_basic',
+    simavr,
+    args : ['-m', 'atmega328p', fs_simavr_exe],
+    is_parallel : false
+  )
+endif

--- a/tests/test_fixed_point.c
+++ b/tests/test_fixed_point.c
@@ -24,9 +24,17 @@ static void boundary_tests(void)
     assert(q8_8_mul(Q8_8_NEG_ONE, Q8_8_ONE) == Q8_8_NEG_ONE);
 }
 
+static void edge_case_tests(void)
+{
+    assert(q8_8_mul(Q8_8_MAX, Q8_8_MAX) == Q8_8_ONE);
+    assert(q8_8_mul(Q8_8_MIN, Q8_8_MAX) == (q8_8_t)0x8081);
+    assert(q8_8_mul(Q8_8_MIN, Q8_8_MIN) == 0);
+}
+
 int main(void)
 {
     boundary_tests();
+    edge_case_tests();
     puts("q8_8_mul boundary tests passed");
     return 0;
 }


### PR DESCRIPTION
## Summary
- expand test_fixed_point with additional edge cases
- new fs_simavr_basic test exercising fs_* via simavr
- wire simavr test in Meson and refactor test flags

## Testing
- `meson test -C build --print-errorlogs` *(fails: undefined reference to q8_8_mul, others)*

------
https://chatgpt.com/codex/tasks/task_e_68561603788c83318539c1b8575d07c7