### PR TITLE
Enable AVR_PREFIX cross-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ meson compile -C build flash           # flash over /dev/ttyACM0
 
 For LLVM: use `cross/atmega328p_clang20.cross`.
 
+### 4A · Custom toolchain prefix
+
+Set `AVR_PREFIX` when the AVR tools live outside `/usr/bin`.  Use the
+helper script to regenerate the cross file and point Meson to it:
+
+```bash
+AVR_PREFIX=/opt/avr/bin ./cross/gen_avr_cross.sh
+meson setup build --wipe --cross-file cross/avr_m328p.txt
+```
+
 ---
 
 ## 5 · Verify install

--- a/cross/avr_m328p.in
+++ b/cross/avr_m328p.in
@@ -1,0 +1,65 @@
+# ────────────────────────────────────────────────────────────────────────
+# cross/avr_m328p.in — GCC-AVR 14 profile for the Arduino Uno R3
+# This is a template. Use gen_avr_cross.sh to generate avr_m328p.txt
+# with a custom AVR toolchain prefix.
+#
+#   AVR_PREFIX=/opt/avr/bin ./cross/gen_avr_cross.sh
+#
+# The default prefix is /usr/bin/.
+# ────────────────────────────────────────────────────────────────────────
+
+[binaries]
+c           = '@AVR_PREFIX@avr-gcc'
+ar          = '@AVR_PREFIX@avr-ar'
+strip       = '@AVR_PREFIX@avr-strip'
+objcopy     = '@AVR_PREFIX@avr-objcopy'
+size        = '@AVR_PREFIX@avr-size'
+exe_wrapper = 'true'                  # no runner for bare-metal tests
+
+[host_machine]
+system      = 'baremetal'
+cpu_family  = 'avr'
+cpu         = 'atmega328p'
+endian      = 'little'
+
+[properties]
+needs_exe_wrapper = true              # suppress Meson warning
+
+c_args = [
+  # MCU + language dialect
+  '-mmcu=atmega328p',
+  '-std=c23',
+  '-DF_CPU=16000000UL',
+
+  # Size-first optimisation
+  '-Oz',                               # smallest code
+  '-flto',                             # GCC 14 Thin-LTO by default
+  '-mrelax', '-mcall-prologues',       # shrink jumps & prologues
+  '-fdata-sections', '-ffunction-sections',
+  '-fmerge-all-constants',
+  '-fno-ident',                        # drop GCC version string
+
+  # Remove unused runtime features
+  '-fno-exceptions', '-fno-rtti',
+  '-fno-unwind-tables', '-fno-asynchronous-unwind-tables',
+  '-fno-stack-protector'
+]
+
+c_link_args = [
+  '-mmcu=atmega328p',
+  '-flto',
+  '-Wl,--gc-sections',                 # dead-code elimination
+  '-Wl,--icf=safe',                    # identical code folding
+  '-Wl,--relax'                        # linker relaxation pass
+]
+
+[built-in options]
+c_std           = 'c23'
+optimization    = 'z'                  # Meson alias for -Oz
+warning_level   = 2
+strip           = true
+default_library = 'none'
+b_staticpic     = false                # irrelevant on AVR
+
+[project options]
+profile         = false                # enable PGO with -Dprofile=true

--- a/cross/avr_m328p.txt
+++ b/cross/avr_m328p.txt
@@ -1,0 +1,65 @@
+# ────────────────────────────────────────────────────────────────────────
+# cross/avr_m328p.in — GCC-AVR 14 profile for the Arduino Uno R3
+# This is a template. Use gen_avr_cross.sh to generate avr_m328p.txt
+# with a custom AVR toolchain prefix.
+#
+#   AVR_PREFIX=/opt/avr/bin ./cross/gen_avr_cross.sh
+#
+# The default prefix is /usr/bin/.
+# ────────────────────────────────────────────────────────────────────────
+
+[binaries]
+c           = '/usr/bin/avr-gcc'
+ar          = '/usr/bin/avr-ar'
+strip       = '/usr/bin/avr-strip'
+objcopy     = '/usr/bin/avr-objcopy'
+size        = '/usr/bin/avr-size'
+exe_wrapper = 'true'                  # no runner for bare-metal tests
+
+[host_machine]
+system      = 'baremetal'
+cpu_family  = 'avr'
+cpu         = 'atmega328p'
+endian      = 'little'
+
+[properties]
+needs_exe_wrapper = true              # suppress Meson warning
+
+c_args = [
+  # MCU + language dialect
+  '-mmcu=atmega328p',
+  '-std=c23',
+  '-DF_CPU=16000000UL',
+
+  # Size-first optimisation
+  '-Oz',                               # smallest code
+  '-flto',                             # GCC 14 Thin-LTO by default
+  '-mrelax', '-mcall-prologues',       # shrink jumps & prologues
+  '-fdata-sections', '-ffunction-sections',
+  '-fmerge-all-constants',
+  '-fno-ident',                        # drop GCC version string
+
+  # Remove unused runtime features
+  '-fno-exceptions', '-fno-rtti',
+  '-fno-unwind-tables', '-fno-asynchronous-unwind-tables',
+  '-fno-stack-protector'
+]
+
+c_link_args = [
+  '-mmcu=atmega328p',
+  '-flto',
+  '-Wl,--gc-sections',                 # dead-code elimination
+  '-Wl,--icf=safe',                    # identical code folding
+  '-Wl,--relax'                        # linker relaxation pass
+]
+
+[built-in options]
+c_std           = 'c23'
+optimization    = 'z'                  # Meson alias for -Oz
+warning_level   = 2
+strip           = true
+default_library = 'none'
+b_staticpic     = false                # irrelevant on AVR
+
+[project options]
+profile         = false                # enable PGO with -Dprofile=true

--- a/cross/gen_avr_cross.sh
+++ b/cross/gen_avr_cross.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ======================================================================
+# gen_avr_cross.sh -- Generate cross/avr_m328p.txt from avr_m328p.in
+# ----------------------------------------------------------------------
+# Usage:
+#   AVR_PREFIX=/opt/avr/bin ./cross/gen_avr_cross.sh
+# ----------------------------------------------------------------------
+# AVR_PREFIX defaults to /usr/bin when not set. A trailing slash is added
+# automatically if missing.
+# ======================================================================
+
+set -euo pipefail
+
+prefix="${AVR_PREFIX:-/usr/bin}"
+[[ ${prefix: -1} != '/' ]] && prefix="${prefix}/"
+
+sed "s|@AVR_PREFIX@|${prefix}|g" "$(dirname "$0")/avr_m328p.in" > "$(dirname "$0")/avr_m328p.txt"
+
+echo "Generated cross/avr_m328p.txt with prefix ${prefix}" >&2


### PR DESCRIPTION
## Summary
- allow environment-specific AVR toolchain prefixes
- document using `AVR_PREFIX` during setup

## Testing
- `meson setup build --wipe`
- `ninja -C build`
- `meson test -C build` *(fails: romfs_basic SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_685615fb1be48331b1a81e3a83ba1073