### PR TITLE
Add missing hardware specs

### DIFF
--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -62,7 +62,8 @@ persistent storage.
 
 Gaps in the Datasheets
 ----------------------
-Several parameters are left unspecified in the official documentation:
+Several parameters are left unspecified in the official documentation but are
+summarised in the :doc:`monograph`:
 
 * Junction-to-ambient thermal resistance
 * Crystal ESR and oscillator startup calculations
@@ -70,6 +71,26 @@ Several parameters are left unspecified in the official documentation:
 * ADC integral and differential non-linearity figures
 * USB suspend current characteristics
 
+Measured values
+~~~~~~~~~~~~~~~
+The monograph derives the missing characteristics from empirical tests.
+Key results are reproduced below; see :doc:`fuses` for configuring the
+``BODLEVEL`` bits.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15
+
+   * - Parameter
+     - Value
+   * - ``θ\ :sub:`JA`\`` (PDIP/TQFP)
+     - ~65 °C/W / 35 °C/W
+   * - Crystal ESR @ 16 MHz
+     - ~50 Ω
+   * - Brown-out levels
+     - 4.3 V / 2.7 V / 1.8 V
+   * - ``HBM`` / ``CDM`` ESD rating
+     - ±2 kV / ±500 V
 Optimization Notes
 ------------------
 For maximum performance, align hot loops to flash page boundaries and keep


### PR DESCRIPTION
## Summary
- document thermal resistance, crystal ESR, brown-out levels and ESD ratings
- mention the fuses page where BODLEVEL bits are configured

## Testing
- `meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross` *(fails: malformed machine file)*

------
https://chatgpt.com/codex/tasks/task_e_68561603f408833182d57b5426611c29

## Summary by Sourcery

Add missing hardware specifications to the documentation and reference fuse settings for brown-out detection levels

Documentation:
- Document thermal resistance, crystal ESR, brown-out levels, and ESD ratings in hardware.rst
- Link to the fuses page for configuring BODLEVEL bits