### PR TITLE
Fix docs index for API

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ Contents
    monograph
    filesystem
    fuses
+   api/library_root
    roadmap-qemu-avr
 
 -------------------------------------------------


### PR DESCRIPTION
## Summary
- expose Doxygen pages via `api/library_root` in `index.rst`

## Testing
- `doxygen Doxyfile`
- `sphinx-build -D breathe_projects.avrix=$(pwd)/build/docs/doxygen/xml docs/source build/docs -a -q`

------
https://chatgpt.com/codex/tasks/task_e_6856160044b083319ae718bc5fdb7ec7

## Summary by Sourcery

Documentation:
- Add link to Doxygen pages under `api/library_root` in index.rst