### PR TITLE
Add spinlock timer test

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,22 @@ Creates two files in TinyLog-4, reads them back, prints via UART.
 
 ---
 
-## 11 · Dockerized QEMU test
+## 11 · Running the test-suite
+
+```bash
+meson test -C build --print-errorlogs
+```
+
+Tests using the host CPU run directly. Cross builds leverage **simavr** so the
+AVR binaries execute in simulation. Ensure `simavr` is installed and available
+in your `$PATH`.
+
+The `spinlock_isr` case stresses the DAG-based spinlock under a 1 kHz timer
+interrupt using `simavr`.  It runs automatically when cross compiling.
+
+---
+
+## 12 · Dockerized QEMU test
 
 ```bash
 docker build -t avrix-qemu docker
@@ -211,7 +226,7 @@ The container compiles the firmware, emits `avrix.img`, then boots QEMU.
 
 ---
 
-## 12 · Gap & friction backlog
+## 13 · Gap & friction backlog
 
 | Gap                                       | Why it matters                                 | Proposed fix                                        |
 | ----------------------------------------- | ---------------------------------------------- | --------------------------------------------------- |

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,13 +33,13 @@ fsmod       = import('fs')
 inc_list    = [inc]                       # base include dir from root
 if host_machine.cpu_family() != 'avr'
   # Host builds use stub AVR headers located in compat/avr
-  inc_list += include_directories(meson.project_source_root() / 'compat')
+  inc_list += include_directories('../compat')
 endif
 avr_opt_dir = get_option('avr_inc_dir')   # optional – user override
 
 if avr_opt_dir != '' and fsmod.is_dir(avr_opt_dir)
   inc_list += include_directories(avr_opt_dir)
-else
+elif meson.is_cross_build()
   sys_avr = '/usr/lib/avr/include'
   if fsmod.is_dir(sys_avr)
     inc_list += include_directories(sys_avr)
@@ -176,3 +176,21 @@ test('flock_stress', flock_exe)
 test('spin_lock',    spin_exe)
 test('superlock_basic', superlock_exe)
 test('romfs_basic',  romfs_exe)
+
+# ───────────────────── 4. Spinlock ISR test via simavr ───────────────
+if meson.is_cross_build()
+  simavr = find_program('simavr', required: false)
+  if simavr.found()
+    spinlock_isr_exe = executable(
+      'spinlock_isr',
+      'spinlock_test.c',
+      link_with           : libavrix,
+      include_directories : inc_list,
+      c_args              : common_cflags
+    )
+    test('spinlock_isr',
+         simavr,
+         args : ['-m', host_machine.cpu(), spinlock_isr_exe],
+         is_parallel : false)
+  endif
+endif

--- a/tests/spinlock_test.c
+++ b/tests/spinlock_test.c
@@ -1,0 +1,39 @@
+#include "nk_lock.h"
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* Global lock shared between main context and the timer ISR. */
+static volatile nk_slock_t g_lock;
+static volatile uint16_t   g_ticks;
+
+/* 1 kHz timer interrupt acquires and releases the lock. */
+ISR(TIMER0_COMPA_vect)
+{
+    nk_slock_lock((nk_slock_t*)&g_lock);
+    nk_slock_unlock((nk_slock_t*)&g_lock);
+    ++g_ticks;
+}
+
+int main(void)
+{
+    nk_slock_init((nk_slock_t*)&g_lock);
+
+    /* Configure Timer0 in CTC mode, prescaler = 64. */
+    TCCR0A = _BV(WGM01);
+    TCCR0B = _BV(CS01) | _BV(CS00);
+    OCR0A  = (uint8_t)((F_CPU / 64UL / 1000UL) - 1);
+    TIMSK0 = _BV(OCIE0A);
+    sei();
+
+    /* Exercise the lock in parallel with the ISR. */
+    for (unsigned i = 0; i < 5000; ++i) {
+        nk_slock_lock((nk_slock_t*)&g_lock);
+        nk_slock_unlock((nk_slock_t*)&g_lock);
+    }
+
+    cli();
+    printf("ticks:%u\n", g_ticks);
+    return g_ticks > 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add spinlock test exercising lock from ISR
- hook into Meson so test runs via simavr when cross compiling
- document how the test runs in README
- avoid AVR header conflicts on native builds

## Testing
- `meson setup build --wipe`
- `meson compile -C build`
- `meson test -C build --print-errorlogs` *(fails: romfs_basic segfault)*

------
https://chatgpt.com/codex/tasks/task_e_685615fdd91483318e887e94fafa3d7f