### PR TITLE
Simplify nk_superlock to use nk_spinlock

### DIFF
--- a/include/nk_spinlock.h
+++ b/include/nk_spinlock.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "nk_lock.h"
+
+/* Lightweight spinlock alias built atop nk_slock */
+typedef nk_slock_t nk_spinlock_t;
+
+/* Static initializer for global spinlocks */
+#define NK_SPINLOCK_STATIC_INIT {0}
+
+static inline void nk_spinlock_init(nk_spinlock_t *s)
+{
+    nk_slock_init(s);
+}
+
+static inline void nk_spinlock_lock(nk_spinlock_t *s)
+{
+    nk_slock_lock(s);
+}
+
+static inline bool nk_spinlock_trylock(nk_spinlock_t *s)
+{
+    return nk_flock_try(&s->base);
+}
+
+static inline void nk_spinlock_unlock(nk_spinlock_t *s)
+{
+    nk_slock_unlock(s);
+}
+
+/* Convenience aliases mirroring nk_slock API */
+#define nk_spinlock_acquire(l)  nk_spinlock_lock(l)
+#define nk_spinlock_release(l)  nk_spinlock_unlock(l)

--- a/include/nk_superlock.h
+++ b/include/nk_superlock.h
@@ -1,137 +1,23 @@
-/* SPDX-License-Identifier: MIT
- * See LICENSE file in the repository root for full license information.
- */
-
-/*─────────────────────────── nk_superlock.h ────────────────────────────*
- * Unified Big Kernel + fine grained spin-lock implementation.
- *
- *  - Built atop the ``nk_slock`` primitives
- *  - Maintains a small copy‑on‑write matrix for speculative state
- *  - Provides a global Big Kernel Lock (BKL) for coarse serialisation
- *  - Exposes a tiny Cap’n Proto compatible snapshot structure
- */
 #pragma once
-#include "nk_lock.h"
-#include <stdint.h>
-#include <stddef.h>
+#include "nk_spinlock.h"
+#define nk_superlock_t      nk_spinlock_t
+#define NK_SUPERLOCK_STATIC_INIT  NK_SPINLOCK_STATIC_INIT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#define nk_superlock_init(l)            nk_spinlock_init(l)
+#define nk_superlock_lock(l, m)         nk_spinlock_lock(l)
+#define nk_superlock_trylock(l, m)      nk_spinlock_trylock(l)
+#define nk_superlock_unlock(l)          nk_spinlock_unlock(l)
+#define nk_superlock_lock_rt(l, m)      nk_spinlock_lock(l)
+#define nk_superlock_trylock_rt(l, m)   nk_spinlock_trylock(l)
+#define nk_superlock_unlock_rt(l)       nk_spinlock_unlock(l)
+#define nk_superlock_acquire(l, m)      nk_superlock_lock((l), (m))
+#define nk_superlock_release(l)         nk_superlock_unlock(l)
+#define nk_superlock_acquire_rt(l, m)   nk_superlock_lock_rt((l), (m))
+#define nk_superlock_release_rt(l)      nk_superlock_unlock_rt(l)
 
-typedef struct {
-    nk_slock_t core;       /* base smart lock */
-    uint8_t    dag_mask;   /* dependency bitmap               */
-    uint8_t    rt_mode;    /* fine-grained real-time mode     */
-    uint32_t   matrix[4];  /* COW matrix snapshot             */
-} nk_superlock_t;
+/* encoding / decoding become no-ops */
+#define nk_superlock_encode(s, out)     ((void)(s), (void)(out))
+#define nk_superlock_decode(s, in)      ((void)(s), (void)(in))
+#define nk_superlock_matrix_set(s,i,v)  ((void)(s), (void)(i), (void)(v))
 
-#define NK_SUPERLOCK_STATIC_INIT { {0}, 0u, 0u, {0, 0, 0, 0} }
-
-extern nk_slock_t nk_bkl;       /* global Big Kernel Lock */
-
-static inline void nk_superlock_init(nk_superlock_t *s)
-{
-    nk_slock_init(&s->core);
-    nk_slock_init(&nk_bkl);
-    s->dag_mask = 0u;
-    s->rt_mode = 0u;
-    for (unsigned i = 0; i < 4; ++i)
-        s->matrix[i] = 0u;
-}
-
-static inline void nk_superlock_lock(nk_superlock_t *s, uint8_t mask)
-{
-    nk_slock_lock(&nk_bkl);
-    nk_slock_lock(&s->core);
-    s->dag_mask = mask;
-    s->rt_mode = 0u;
-}
-
-static inline bool nk_superlock_trylock(nk_superlock_t *s, uint8_t mask)
-{
-    if (!nk_flock_try(&nk_bkl.base))
-        return false;
-    if (!nk_flock_try(&s->core.base)) {
-        nk_flock_unlock(&nk_bkl.base);
-        return false;
-    }
-    s->dag_mask = mask;
-    s->rt_mode = 0u;
-    return true;
-}
-
-static inline void nk_superlock_unlock(nk_superlock_t *s)
-{
-    s->dag_mask = 0u;
-    s->rt_mode = 0u;
-    nk_slock_unlock(&s->core);
-    nk_slock_unlock(&nk_bkl);
-}
-
-/*--------------------------------------------------------------*
- * Real-time mode : bypass the global BKL for fine-grained locking
- *--------------------------------------------------------------*/
-static inline void nk_superlock_lock_rt(nk_superlock_t *s, uint8_t mask)
-{
-    nk_slock_lock(&s->core);
-    s->dag_mask = mask;
-    s->rt_mode = 1u;
-}
-
-static inline bool nk_superlock_trylock_rt(nk_superlock_t *s, uint8_t mask)
-{
-    if (!nk_flock_try(&s->core.base))
-        return false;
-    s->dag_mask = mask;
-    s->rt_mode = 1u;
-    return true;
-}
-
-static inline void nk_superlock_unlock_rt(nk_superlock_t *s)
-{
-    s->dag_mask = 0u;
-    s->rt_mode = 0u;
-    nk_slock_unlock(&s->core);
-}
-
-/* Cap'n Proto like structure for serialised state */
-typedef struct {
-    uint8_t  dag_mask;
-    uint32_t matrix[4];
-} nk_superlock_capnp_t;
-
-static inline void nk_superlock_encode(const nk_superlock_t *s,
-                                       nk_superlock_capnp_t *out)
-{
-    out->dag_mask = s->dag_mask;
-    for (unsigned i = 0; i < 4; ++i)
-        out->matrix[i] = s->matrix[i];
-}
-
-static inline void nk_superlock_decode(nk_superlock_t *s,
-                                       const nk_superlock_capnp_t *in)
-{
-    s->dag_mask = in->dag_mask;
-    for (unsigned i = 0; i < 4; ++i)
-        s->matrix[i] = in->matrix[i];
-}
-
-/* granular matrix update for speculative COW state */
-static inline void nk_superlock_matrix_set(nk_superlock_t *s,
-                                           unsigned idx, uint32_t val)
-{
-    if (idx < 4)
-        s->matrix[idx] = val;
-}
-
-/* shorthand aliases mirroring nk_slock API */
-#define nk_superlock_acquire(s, m)     nk_superlock_lock((s), (m))
-#define nk_superlock_release(s)        nk_superlock_unlock((s))
-#define nk_superlock_acquire_rt(s, m)  nk_superlock_lock_rt((s), (m))
-#define nk_superlock_release_rt(s)     nk_superlock_unlock_rt((s))
-
-#ifdef __cplusplus
-}
-#endif
-
+extern nk_spinlock_t nk_bkl;

--- a/src/nk_superlock.c
+++ b/src/nk_superlock.c
@@ -7,5 +7,6 @@
 /* Global Big Kernel Lock shared across all superlock instances. */
 /* This spinlock composes all DAG/Lattice features of the base lock. */
 
-nk_slock_t nk_bkl = {0};
+/* Big Kernel Lock implemented as a basic spinlock. */
+nk_spinlock_t nk_bkl = NK_SPINLOCK_STATIC_INIT;
 


### PR DESCRIPTION
## Summary
- add lightweight `nk_spinlock` implementation
- alias `nk_superlock` API to the new spinlock
- update global BKL implementation

## Testing
- `meson setup build` *(fails: Expecting rparen got colon)*

------
https://chatgpt.com/codex/tasks/task_e_68562625d13c8331a0432c7fd328b418

## Summary by Sourcery

Simplify the nk_superlock abstraction by implementing a dedicated nk_spinlock and aliasing all superlock functionality to this lightweight spinlock, removing the previous copy-on-write matrix and real-time mode features.

New Features:
- Introduce a lightweight nk_spinlock type built atop nk_slock

Enhancements:
- Alias nk_superlock API and type to the new nk_spinlock implementation
- Replace heavyweight superlock internal logic (DAG mask, matrix, RT mode) with spinlock macros
- Update global Big Kernel Lock (nk_bkl) to use nk_spinlock