### PR TITLE
Introduce nk_spinlock wrapper

### DIFF
--- a/include/nk_spinlock.h
+++ b/include/nk_spinlock.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: MIT
+ * See LICENSE file in the repository root for full license information.
+ */
+
+#ifndef NK_SPINLOCK_H
+#define NK_SPINLOCK_H
+
+#include "nk_lock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Simplified spinlock API built on top of the nk_slock primitives. */
+typedef nk_slock_t nk_spinlock_t;
+
+/** Static initializer suitable for global or static instances. */
+#define NK_SPINLOCK_STATIC_INIT {0}
+
+static inline void nk_spinlock_init(nk_spinlock_t *l)
+{
+    nk_slock_init(l);
+}
+
+static inline void nk_spinlock_lock_rt(nk_spinlock_t *l)
+{
+    nk_slock_lock(l);
+}
+
+static inline void nk_spinlock_unlock_rt(nk_spinlock_t *l)
+{
+    nk_slock_unlock(l);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NK_SPINLOCK_H */

--- a/tests/spinlock_test.c
+++ b/tests/spinlock_test.c
@@ -1,24 +1,24 @@
-#include "nk_lock.h"
+#include "nk_spinlock.h"
 #include <avr/io.h>
 #include <avr/interrupt.h>
 #include <stdint.h>
 #include <stdio.h>
 
 /* Global lock shared between main context and the timer ISR. */
-static volatile nk_slock_t g_lock;
+static volatile nk_spinlock_t g_lock = NK_SPINLOCK_STATIC_INIT;
 static volatile uint16_t   g_ticks;
 
 /* 1 kHz timer interrupt acquires and releases the lock. */
 ISR(TIMER0_COMPA_vect)
 {
-    nk_slock_lock((nk_slock_t*)&g_lock);
-    nk_slock_unlock((nk_slock_t*)&g_lock);
+    nk_spinlock_lock_rt((nk_spinlock_t*)&g_lock);
+    nk_spinlock_unlock_rt((nk_spinlock_t*)&g_lock);
     ++g_ticks;
 }
 
 int main(void)
 {
-    nk_slock_init((nk_slock_t*)&g_lock);
+    nk_spinlock_init((nk_spinlock_t*)&g_lock);
 
     /* Configure Timer0 in CTC mode, prescaler = 64. */
     TCCR0A = _BV(WGM01);
@@ -29,8 +29,8 @@ int main(void)
 
     /* Exercise the lock in parallel with the ISR. */
     for (unsigned i = 0; i < 5000; ++i) {
-        nk_slock_lock((nk_slock_t*)&g_lock);
-        nk_slock_unlock((nk_slock_t*)&g_lock);
+        nk_spinlock_lock_rt((nk_spinlock_t*)&g_lock);
+        nk_spinlock_unlock_rt((nk_spinlock_t*)&g_lock);
     }
 
     cli();


### PR DESCRIPTION
## Summary
- wrap nk_slock functionality behind new `nk_spinlock.h`
- switch `spinlock_test` to the new API with rt helpers

## Testing
- `meson setup build` *(fails: Expecting rparen got colon)*
- `meson compile -C build` *(failed: build directory invalid)*

------
https://chatgpt.com/codex/tasks/task_e_685626301b2c833199ee33066986ba43