### PR TITLE
Fix Meson syntax for tests

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,9 @@ option('flash_port', type: 'string', value: '/dev/ttyACM0',
        description: 'Serial device for avrdude')
 option('flash_programmer', type: 'string', value: 'arduino',
        description: 'Programmer string for avrdude')
+
+option('san', type: 'combo', choices: ['yes', 'no'], value: 'no',
+       description: 'Enable Address/UB sanitizers for host tests')
+
+option('cov', type: 'combo', choices: ['yes', 'no'], value: 'no',
+       description: 'Enable LLVM coverage instrumentation for host tests')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -60,14 +60,9 @@ if not meson.is_cross_build()
 endif
 
 # Helper: always build the test binary for the host CPU ----------------
-build_test = (name : str, srcs : list, link_target) =>
-  executable(
-    name,
-    srcs,
-    include_directories : inc_list,
-    link_with           : link_target,
-    c_args              : common_cflags,
-    native              : true)
+# Build a test executable for the host CPU using consistent flags.
+# Meson 1.3 does not support arrow functions, so we invoke
+# `executable()` directly each time instead of wrapping it.
 
 # Extra stub source for host-only builds
 extra_src = []
@@ -89,7 +84,13 @@ tests = [
 ]
 
 foreach t : tests
-  exe = build_test(t.get(0), t.get(1) + extra_src, link_target)
+  exe = executable(
+    t.get(0),
+    t.get(1) + extra_src,
+    include_directories : inc_list,
+    link_with           : link_target,
+    c_args              : common_cflags,
+    native              : true)
   test(t.get(0), exe)
 endforeach
 


### PR DESCRIPTION
## Summary
- add missing coverage and sanitizer options
- drop arrow function in tests/meson.build for Meson 1.3 compatibility
- call `executable()` directly for each unit test

## Testing
- `meson setup build`
- `meson compile -C build` *(fails: multiple definition of `nk_sim_io`)*

------
https://chatgpt.com/codex/tasks/task_e_6856260ee17c8331bc05eba1a75ac0a8