### PR TITLE
Update toolchain docs with additional cross files

### DIFF
--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -164,6 +164,18 @@ For a *legacy* build drop ``--icf`` / ``-fipa-pta`` and switch
         -Dflash_port=/dev/ttyACM0 -Dflash_programmer=arduino
 
 ``cross/atmega328p_clang20.cross`` is provided for LLVM 20 users.
+``cross/atmega32.cross`` and ``cross/atmega128.cross`` extend the
+selection to DIP‐40 and larger ATmega128 boards.
+
+.. code-block:: bash
+
+   meson setup build32  --wipe --cross-file cross/atmega32.cross
+   meson setup build128 --wipe --cross-file cross/atmega128.cross
+
+``atmega32.cross`` mirrors the ``328p`` flags, merely changing the MCU
+type. ``atmega128.cross`` enables extra hardening flags such as
+``-fstack-protector-strong`` and ``-D_FORTIFY_SOURCE=2`` while printing
+memory usage at link time.
 
 ----------------------------------------------------------------------
 7 · Documentation targets


### PR DESCRIPTION
## Summary
- document `cross/atmega32.cross` and `cross/atmega128.cross`
- show how to invoke Meson with these files
- note compiler flag differences

## Testing
- `pytest -q tests/test_check_docs_cli.py tests/test_check_docs_parser.py tests/test_check_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_685625e775b4833199f0105f2f9c819e

## Summary by Sourcery

Update the toolchain documentation with new cross files, usage instructions, and compiler flag notes

Documentation:
- Add documentation for cross/atmega32.cross and cross/atmega128.cross configuration files
- Include examples showing how to invoke Meson with the new cross files
- Highlight the differences in compiler flags for the AVR toolchain