### PR TITLE
Add memguard documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 build/
-source/api/
+source/api/*
+!source/api/library_root.rst

--- a/docs/source/api/library_root.rst
+++ b/docs/source/api/library_root.rst
@@ -1,0 +1,4 @@
+API Reference
+=============
+
+Placeholder for Exhale-generated API docs.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ Contents
    monograph
    filesystem
    slip_networking
+   memguard
    fuses
    api/library_root
    roadmap-qemu-avr

--- a/docs/source/memguard.rst
+++ b/docs/source/memguard.rst
@@ -1,0 +1,37 @@
+Memory Guard Utilities
+======================
+
+The :file:`memguard.h` helpers provide a small runtime check for buffer
+overflows. Each guarded region reserves :c:macro:`GUARD_BYTES` sentinel
+bytes on either side, filled with the value ``0xA5`` as defined by
+:c:macro:`GUARD_PATTERN`.
+
+Guarded buffers are initialised with :c:func:`guard_init` and validated
+with :c:func:`check_guard`.  This mechanism is intended for unit tests
+where lightweight detection of stack or heap corruption is valuable.
+
+Example usage
+-------------
+
+.. code-block:: c
+
+   #include "memguard.h"
+
+   static uint8_t raw[16 + 2 * GUARD_BYTES];
+   /* User-facing slice excluding the sentinels */
+   static uint8_t *buf = raw + GUARD_BYTES;
+
+   int main(void)
+   {
+       guard_init(raw, sizeof raw);
+       /* application fills `buf` with data */
+       if (!check_guard(raw, sizeof raw)) {
+           /* overflow detected */
+           return 1;
+       }
+       return 0;
+   }
+
+``guard_init`` writes ``0xA5`` at both ends of ``raw``.  After the buffer
+is used, ``check_guard`` ensures the sentinels remain untouched.  Any
+modification indicates a write outside the intended region.


### PR DESCRIPTION
## Summary
- document the memguard helper utilities
- link the page from the main toctree
- keep a placeholder API root so link checks pass

## Testing
- `python3 tests/check_docs.py --docs-dir docs/source --index-file docs/source/index.rst --recursive`

------
https://chatgpt.com/codex/tasks/task_e_685625e65144833189070766130d4566

## Summary by Sourcery

Add and integrate documentation for the memguard helper utilities

Documentation:
- Introduce a new memguard.rst page documenting the memguard helpers
- Include the memguard documentation in the main toctree via index.rst
- Add a placeholder API root file to satisfy link checks