### PR TITLE
Add scheduler default macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,26 @@ meson setup build --cross-file cross/atmega328p_gcc14.cross \
 
 ---
 
+### 6A · Stack & quantum overrides
+
+```c
+#ifndef NK_STACK_SIZE
+#define NK_STACK_SIZE 128u           /* bytes per task stack */
+#endif
+#ifndef NK_QUANTUM_MS
+#define NK_QUANTUM_MS 10u            /* round-robin slice */
+#endif
+```
+
+Override at configure-time:
+
+```bash
+meson setup build --cross-file cross/atmega328p_gcc14.cross \
+                  -Dc_args="-DNK_STACK_SIZE=256 -DNK_QUANTUM_MS=5"
+```
+
+---
+
 ## 7 · Hardware target
 
 | Chip           | Role            | Clock          | Flash / SRAM | Notes               |

--- a/include/nk_task.h
+++ b/include/nk_task.h
@@ -35,6 +35,14 @@ extern "C" {             /* header is C23-pure but callable from C++ */
 #  define NK_OPT_DAG_WAIT  0
 #endif
 
+/* Per-task stack size in bytes and scheduler quantum in ms */
+#ifndef NK_STACK_SIZE
+#  define NK_STACK_SIZE 128u
+#endif
+#ifndef NK_QUANTUM_MS
+#  define NK_QUANTUM_MS 10u
+#endif
+
 _Static_assert(NK_MAX_TASKS <= 8,
                "NK_MAX_TASKS > 8 breaks SRAM budget");
 

--- a/include/task.h
+++ b/include/task.h
@@ -35,6 +35,14 @@ extern "C" {             /* header is C23-pure but callable from C++ */
 #  define NK_OPT_DAG_WAIT  0
 #endif
 
+/* Per-task stack size in bytes and scheduler quantum in ms */
+#ifndef NK_STACK_SIZE
+#  define NK_STACK_SIZE 128u
+#endif
+#ifndef NK_QUANTUM_MS
+#  define NK_QUANTUM_MS 10u
+#endif
+
 _Static_assert(NK_MAX_TASKS <= 8,
                "NK_MAX_TASKS > 8 breaks SRAM budget");
 


### PR DESCRIPTION
## Summary
- set NK_STACK_SIZE and NK_QUANTUM_MS defaults
- document build-time override for those values in README

## Testing
- `meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross` *(fails: malformed machine file)*
- `meson setup build --wipe` *(fails: Expecting rparen got colon)*

------
https://chatgpt.com/codex/tasks/task_e_685625da43e083318a6593776a5fcdb2