### PR TITLE
Add static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,47 @@
+# .github/workflows/static-analysis.yml
+#
+# µ-UNIX (Avrix) Static-Analysis pipeline
+# ───────────────────────────────────────
+# • Installs clang-tidy and cppcheck
+# • Runs both analyzers over the sources on pull requests
+# • Fails on any emitted warning
+
+name: Static analysis
+
+on:
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # ── 0 · Checkout ────────────────────────────────────────────────────
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      # ── 1 · Dependencies ───────────────────────────────────────────────
+      - name: Install clang-tidy & cppcheck
+        run: |
+          sudo apt-get -yq update
+          sudo apt-get -yq install clang-tidy cppcheck gcc-avr avr-libc
+
+      # ── 2 · cppcheck ───────────────────────────────────────────────────
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=all --error-exitcode=1 --inline-suppr \
+                   -Iinclude src tests
+
+      # ── 3 · clang-tidy ─────────────────────────────────────────────────
+      - name: Run clang-tidy
+        run: |
+          for f in $(git ls-files '*.c'); do
+            echo "[tidy] $f"
+            clang-tidy "$f" --quiet --warnings-as-errors='*' -- \
+              -std=c23 -mmcu=atmega328p -DF_CPU=16000000UL -Iinclude \
+              -I/usr/lib/avr/include
+          done
+

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ The container compiles the firmware, emits `avrix.img`, then boots QEMU.
 | **Real-board flash helper**               | newcomers still need the `avrdude` incantation | `meson compile -C build flash` flashes the Uno |
 | **tmux-dev launcher**                     | 4-pane session exists only in docs             | ship `scripts/tmux-dev.sh`                          |
 | **On-device GDB stub**                    | “printf + LED” is clumsy                       | gate tiny `avr-gdbstub` behind `-DDEBUG_GDB`        |
-| **Static-analysis CI**                    | cppcheck runs locally only                     | add `cppcheck/clang-tidy` GitHub job                |
+| **Static-analysis CI**                    | cppcheck runs locally only                     | ✅ `cppcheck` & `clang-tidy` GitHub job                |
 | **Binary-size guardrail**                 | flash creep goes unnoticed                     | Meson `size-gate` custom target (< 30 kB)           |
 | *(full table continues in README source)* |                                                |                                                     |
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for cppcheck and clang-tidy
- mark backlog item as done in README

## Testing
- `meson --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685625d0765083319291d7624cd77c2b

## Summary by Sourcery

Introduce a static-analysis pipeline using cppcheck and clang-tidy in GitHub Actions and update documentation to reflect its completion.

New Features:
- Add a GitHub Actions workflow to run cppcheck and clang-tidy on pull requests

CI:
- Fail the CI job on any static-analysis warnings

Documentation:
- Update README to mark the static-analysis CI item as completed