### PR TITLE
Add Uno flash helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The container compiles the firmware, emits `avrix.img`, then boots QEMU.
 
 | Gap                                       | Why it matters                                 | Proposed fix                                        |
 | ----------------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
-| **Real-board flash helper**               | newcomers still need the `avrdude` incantation | `meson compile -C build flash` flashes the Uno |
+| **Real-board flash helper**               | newcomers still need the `avrdude` incantation | `scripts/flash.sh build/unix0.hex` flashes the Uno |
 | **tmux-dev launcher**                     | 4-pane session exists only in docs             | ship `scripts/tmux-dev.sh`                          |
 | **On-device GDB stub**                    | “printf + LED” is clumsy                       | gate tiny `avr-gdbstub` behind `-DDEBUG_GDB`        |
 | **Static-analysis CI**                    | cppcheck runs locally only                     | add `cppcheck/clang-tidy` GitHub job                |

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ======================================================================
+#  flash.sh -- Uno R3 flashing helper
+# ----------------------------------------------------------------------
+#  Usage:
+#    scripts/flash.sh firmware.hex [port]
+#
+#  Auto-detects /dev/ttyACM* when no port is given. After programming
+#  the flash, the script dumps lfuse, hfuse, efuse and lock bits.
+# ======================================================================
+set -euo pipefail
+
+HEX=${1:-}
+if [[ -z "$HEX" || ! -f "$HEX" ]]; then
+  echo "Usage: $0 firmware.hex [port]" >&2
+  exit 1
+fi
+
+PORT=${2:-${FLASH_PORT:-}}
+if [[ -z "$PORT" ]]; then
+  PORT=$(find /dev -maxdepth 1 -name 'ttyACM*' 2>/dev/null | head -n1 || true)
+fi
+
+if [[ -z "$PORT" ]]; then
+  echo "[error] no /dev/ttyACM* device found" >&2
+  exit 1
+fi
+
+PROG=arduino
+MCU=m328p
+
+printf '[info] Flashing %s to %s\n' "$HEX" "$PORT"
+avrdude -c "$PROG" -p "$MCU" -P "$PORT" -D -U "flash:w:$HEX" || exit 1
+
+echo
+printf '[info] Fuse and lock bytes:\n'
+avrdude -c "$PROG" -p "$MCU" -P "$PORT" \
+  -U lfuse:r:-:i -U hfuse:r:-:i -U efuse:r:-:i -U lock:r:-:i \
+  | awk '/lfuse|hfuse|efuse|lock/'


### PR DESCRIPTION
## Summary
- add `scripts/flash.sh` as a simple avrdude wrapper
- update README gap table to reference the new script

## Testing
- `bash -n scripts/flash.sh`
- `shellcheck scripts/flash.sh`
- `apt-get update`
- `apt-get install -y shellcheck`


------
https://chatgpt.com/codex/tasks/task_e_685625bc608c8331bb7d080f7ddb71b4