### PR TITLE
Add firmware size gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Compile targets
         run: meson compile -C build
 
+      - name: Enforce flash budget
+        run: meson compile -C build size-gate
+
       # ── 4 · Test ───────────────────────────────────────────────────────
       - name: Run test-suite
         run: meson test -C build --print-errorlogs

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ meson setup build --wipe --cross-file cross/atmega328p_gcc14.cross
 meson compile -C build
 qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
 meson compile -C build flash           # flash over /dev/ttyACM0
+meson compile -C build size-gate       # fail if firmware > 30 kB
 ```
 
 For LLVM: use `cross/atmega328p_clang20.cross`.

--- a/scripts/size_gate.py
+++ b/scripts/size_gate.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Fail if the AVR firmware exceeds the flash budget."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ELF = Path(sys.argv[1])
+LIMIT = 30 * 1024  # 30 KiB flash budget
+
+try:
+    out = subprocess.check_output(['avr-size', '-A', ELF], text=True)
+except FileNotFoundError:
+    sys.exit('avr-size not found')
+
+# Sum sections that occupy flash memory
+flash = 0
+for line in out.splitlines():
+    fields = line.split()
+    if len(fields) >= 2 and fields[0] in {'.text', '.rodata', '.data'}:
+        flash += int(fields[1])
+print(out)
+
+if flash > LIMIT:
+    print(f'Firmware size {flash} bytes exceeds 30 KiB limit', file=sys.stderr)
+    sys.exit(1)

--- a/src/meson.build
+++ b/src/meson.build
@@ -134,5 +134,15 @@ if meson.is_cross_build()
       ],
       console : true
     )
+
+    # ── Firmware size guard -----------------------------------------------
+    size_script = meson.project_source_root() / 'scripts/size_gate.py'
+    custom_target(
+      'size-gate',
+      input  : demo_elf,
+      output : 'size-gate.stamp',
+      command: [size_script, '@INPUT@'],
+      console: true
+    )
   endif
 endif


### PR DESCRIPTION
## Summary
- enforce flash budget via `size-gate`
- run gate in CI
- mention the new target in the README

## Testing
- `meson setup build --wipe` *(fails: Expecting rparen got colon)*

------
https://chatgpt.com/codex/tasks/task_e_685625bfbb088331885fe8cc7489b563

## Summary by Sourcery

Introduce a firmware size gate to verify flash usage doesn’t exceed 30 KiB by integrating a new size-check script into the Meson build, CI pipeline, and documentation.

New Features:
- Add a Python script to enforce a 30 KiB firmware flash size limit

Build:
- Define a Meson custom target 'size-gate' to run the size-check script

CI:
- Add a GitHub Actions step to invoke the size-gate target in CI

Documentation:
- Update README with instructions for running the size-gate