### PR TITLE
Use project path for compat includes

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -39,7 +39,7 @@ test(
 inc_list = [inc]
 
 if host_machine.cpu_family() != 'avr'
-  inc_list += include_directories('../compat')
+  inc_list += include_directories(meson.project_source_root() / 'compat')
 endif
 
 avr_inc = get_option('avr_inc_dir')


### PR DESCRIPTION
## Summary
- update `tests/meson.build` to refer to compat headers via `meson.project_source_root()`
- attempt to reconfigure in a new build directory

## Testing
- `meson setup build` *(fails: absolute path inside source tree is rejected)*

------
https://chatgpt.com/codex/tasks/task_e_6858a9c113c88331a49c4b62b7f5fd84

## Summary by Sourcery

Use the Meson project source root for compat headers in tests to enable out-of-tree builds.

Bug Fixes:
- Allow Meson to configure the build in a separate directory by resolving include paths correctly

Enhancements:
- Update tests/meson.build to include the compat directory via meson.project_source_root() instead of a relative path