### PR TITLE
Validate fs_create names

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -3,6 +3,7 @@
  */
 
 #include "fs.h"
+#include <errno.h>
 #include <string.h>
 
 /** Simple in-memory disk image. Each block is \c FS_BLOCK_SIZE bytes. */
@@ -64,6 +65,21 @@ void fs_init(void) {
 }
 
 int fs_create(const char *name, uint8_t type) {
+    if (name == NULL) {
+        return -EINVAL;
+    }
+
+    size_t len = strnlen(name, FS_MAX_NAME + 1);
+    if (len == 0 || len > 13) {
+        return -EINVAL;
+    }
+
+    for (uint8_t i = 0; i < FS_NUM_INODES; ++i) {
+        if (inodes[i].type && strncmp(dir_name[i], name, FS_MAX_NAME) == 0) {
+            return -EEXIST;
+        }
+    }
+
     int inum = ialloc(type);
     if (inum < 0) {
         return -1;

--- a/tests/fs_test.c
+++ b/tests/fs_test.c
@@ -1,6 +1,7 @@
 #include "fs.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -8,11 +9,17 @@ int main(void)
 {
     fs_init();
 
+    /* invalid name checks */
+    assert(fs_create("", 1) == -EINVAL);
+    assert(fs_create("aaaaaaaaaaaaaa", 1) == -EINVAL);
+
     /*
      * Reserve block zero so that a real file never maps to block number
      * zero. This simplifies the checks below.
      */
     int dummy = fs_create("dummy", 1);
+    assert(dummy >= 0);
+    assert(fs_create("dummy", 1) == -EEXIST);
     file_t d;
     assert(fs_open("dummy", &d) == 0);
     char c = 'x';


### PR DESCRIPTION
## Summary
- improve error handling in `fs_create`
- extend `fs_test` for edge cases

## Testing
- `gcc -std=c2x -O2 -Wall -Wextra -pedantic tests/fs_test.c tests/sim.c src/fs.c src/avr_stub.c -Iinclude -Icompat -o fs_test && ./fs_test`

------
https://chatgpt.com/codex/tasks/task_e_6858a9be667c833185be9ab73271dd14