### PR TITLE
Wrap pgm_read_word for host build

### DIFF
--- a/src/eepfs.c
+++ b/src/eepfs.c
@@ -80,11 +80,20 @@ const eepfs_file_t *eepfs_open(const char *path)
             p++;
         uint8_t count = pgm_read_byte(&dir->count);
         eepfs_entry_t ent;
-        const eepfs_entry_t *ents = (const eepfs_entry_t *)pgm_read_word(&dir->entries);
+#ifdef __AVR__
+        const eepfs_entry_t *ents =
+            (const eepfs_entry_t *)pgm_read_word(&dir->entries);
+#else
+        const eepfs_entry_t *ents = dir->entries;
+#endif
         bool found = false;
         for (uint8_t i = 0; i < count; i++) {
             memcpy_P(&ent, &ents[i], sizeof ent);
+#ifdef __AVR__
             const char *nm = (const char *)pgm_read_word(&ent.name);
+#else
+            const char *nm = ent.name;
+#endif
             if (eq_p(seg, nm)) {
                 found = true;
                 if (*p == '\0' && ent.type == EEPFS_FILE) {

--- a/src/romfs.c
+++ b/src/romfs.c
@@ -100,11 +100,20 @@ const romfs_file_t *romfs_open(const char *path)
             p++;
         uint8_t count = pgm_read_byte(&dir->count);
         romfs_entry_t entry;
-        const romfs_entry_t *entries = (const romfs_entry_t *)pgm_read_word(&dir->entries);
+#ifdef __AVR__
+        const romfs_entry_t *entries =
+            (const romfs_entry_t *)pgm_read_word(&dir->entries);
+#else
+        const romfs_entry_t *entries = dir->entries;
+#endif
         bool found = false;
         for (uint8_t i = 0; i < count; i++) {
             memcpy_P(&entry, &entries[i], sizeof entry);
+#ifdef __AVR__
             const char *nm = (const char *)pgm_read_word(&entry.name);
+#else
+            const char *nm = entry.name;
+#endif
             if (equal_p(seg, nm)) {
                 found = true;
                 if (*p == '\0' && entry.type == ROMFS_FILE) {


### PR DESCRIPTION
## Summary
- use host pointers when not compiling for AVR
- rebuild host tests

## Testing
- `cc -std=c2x -Iinclude -Icompat -Isrc tests/romfs_test.c src/romfs.c src/eepfs.c src/avr_stub.c -o /tmp/romfs_test && /tmp/romfs_test`

------
https://chatgpt.com/codex/tasks/task_e_6858a9be19048331ad27617de1f1033d