### PR TITLE
Implement global status message utility

### DIFF
--- a/examples/editor_common.c
+++ b/examples/editor_common.c
@@ -1,0 +1,14 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include "editor_common.h"
+
+char status_msg[64];
+
+void set_status_message(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(status_msg, sizeof status_msg, fmt, ap);
+    va_end(ap);
+}

--- a/examples/editor_common.h
+++ b/examples/editor_common.h
@@ -65,6 +65,9 @@ static inline void delete_line(char lines[][MAX_LINE_LEN], uint8_t *count,
     --*count;
 }
 
+void set_status_message(const char *fmt, ...);
+extern char status_msg[64];
+
 #ifdef __cplusplus
 }
 #endif

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -51,9 +51,10 @@ if host_machine.cpu_family() == 'avr'
   opt_cflags += ['-fno-stack-protector']
 endif
 
+
 ned = executable(
   'ned',
-  'ned.c',
+  ['ned.c', 'editor_common.c'],
   include_directories: inc,
   link_with: libavrix,
   c_args: opt_cflags,
@@ -62,7 +63,7 @@ ned = executable(
 
 vini = executable(
   'vini',
-  'vini.c',
+  ['vini.c', 'editor_common.c'],
   include_directories: inc,
   link_with: libavrix,
   c_args: opt_cflags,

--- a/examples/ned.c
+++ b/examples/ned.c
@@ -163,21 +163,36 @@ int main(int argc, char **argv) {
     if (cmd[0] == 'e') {
       unsigned int line;
       char text[200];
-      if (sscanf(cmd + 1, "%u %[\x00-\xFF]", &line, text) == 2 && line)
+      if (sscanf(cmd + 1, "%u %[\x00-\xFF]", &line, text) == 2 && line) {
+        if (strlen(text) >= MAX_LINE_LEN) {
+          set_status_message("Line truncated to %d chars", MAX_LINE_LEN - 1);
+          printf("%s\n", status_msg);
+        }
         replace_line(&buf, (uint8_t)(line - 1), text);
+      }
       continue;
     }
     if (cmd[0] == 'i') {
       unsigned int line;
       char text[200];
-      if (sscanf(cmd + 1, "%u %[\x00-\xFF]", &line, text) == 2)
+      if (sscanf(cmd + 1, "%u %[\x00-\xFF]", &line, text) == 2) {
+        if (strlen(text) >= MAX_LINE_LEN) {
+          set_status_message("Line truncated to %d chars", MAX_LINE_LEN - 1);
+          printf("%s\n", status_msg);
+        }
         insert_line(&buf, (uint8_t)(line - 1), text);
+      }
       continue;
     }
     if (cmd[0] == 'a') {
       char text[200];
-      if (sscanf(cmd + 1, " %[\x00-\xFF]", text) == 1)
+      if (sscanf(cmd + 1, " %[\x00-\xFF]", text) == 1) {
+        if (strlen(text) >= MAX_LINE_LEN) {
+          set_status_message("Line truncated to %d chars", MAX_LINE_LEN - 1);
+          printf("%s\n", status_msg);
+        }
         insert_line(&buf, buf.count, text);
+      }
       continue;
     }
     if (cmd[0] == 'd') {

--- a/examples/vini.c
+++ b/examples/vini.c
@@ -186,16 +186,8 @@ static void draw(const struct Buffer *b, uint8_t row, uint8_t col, int mode) {
   }
 }
 
-static char status_msg[64];
 static int  status_timer;
 static char yank[MAX_LINE_LEN] = "";
-
-static void set_status_message(const char *msg)
-{
-  strncpy(status_msg, msg, sizeof status_msg - 1);
-  status_msg[sizeof status_msg - 1] = '\0';
-  status_timer = 5;
-}
 
 static void command_loop(struct Buffer *b, const char *path) {
   uint8_t row = 0, col = 0;


### PR DESCRIPTION
## Summary
- create `editor_common.c` with `set_status_message`
- expose `status_msg` and `set_status_message` in `editor_common.h`
- link `editor_common.c` to `ned` and `vini`
- use global status handling in `vini`
- show feedback when lines exceed length in `ned`

## Testing
- `meson setup build --wipe` *(fails: File superlock_test.c does not exist)*
- `meson compile -C build` *(fails: current directory is not a meson build dir)*

------
https://chatgpt.com/codex/tasks/task_e_6858a9b988e4833194e704dded05e4d5