### PR TITLE
Refactor editor helpers

### DIFF
--- a/examples/editor_common.c
+++ b/examples/editor_common.c
@@ -1,0 +1,95 @@
+#include "editor_common.h"
+
+#ifdef __AVR__
+#include <avr/pgmspace.h>
+#else
+#include "../compat/avr/pgmspace.h"
+#include <wchar.h>
+#include <locale.h>
+#endif
+
+void pgm_print(const char *p)
+{
+#ifdef __AVR__
+    for (char c = pgm_read_byte(p); c; c = pgm_read_byte(++p))
+        putchar(c);
+#else
+    fputs(p, stdout);
+#endif
+}
+
+void highlight(const char *line)
+{
+    if (strncmp(line, "//", 2) == 0 || line[0] == '#') {
+        printf("\x1b[33m%s\x1b[0m", line);
+        return;
+    }
+
+    for (const char *p = line; *p; ++p) {
+        if (isdigit((unsigned char)*p))
+            printf("\x1b[36m%c\x1b[0m", *p);
+        else
+            putchar(*p);
+    }
+}
+
+void insert_line(char lines[][MAX_LINE_LEN], uint8_t *count,
+                 uint8_t idx, const char *text)
+{
+    if (*count >= MAX_LINES)
+        return;
+    if (idx > *count)
+        idx = *count;
+    for (uint8_t i = *count; i > idx; --i)
+        memcpy(lines[i], lines[i - 1], MAX_LINE_LEN);
+    strncpy(lines[idx], text, MAX_LINE_LEN - 1);
+    lines[idx][MAX_LINE_LEN - 1] = '\0';
+    ++*count;
+}
+
+void delete_line(char lines[][MAX_LINE_LEN], uint8_t *count,
+                 uint8_t idx)
+{
+    if (idx >= *count)
+        return;
+    for (uint8_t i = idx; i + 1 < *count; ++i)
+        memcpy(lines[i], lines[i + 1], MAX_LINE_LEN);
+    --*count;
+}
+
+int display_width(const char *s, size_t byte_offset)
+{
+#ifdef __AVR__
+    int width = 0;
+    for (size_t i = 0; i < byte_offset && s[i]; ++i) {
+        if (s[i] == '\t')
+            width += 8 - (width % 8);
+        else
+            ++width;
+    }
+    return width;
+#else
+    int width = 0;
+    size_t i = 0;
+    setlocale(LC_CTYPE, "");
+    while (i < byte_offset && s[i]) {
+        if (s[i] == '\t') {
+            width += 8 - (width % 8);
+            ++i;
+        } else {
+            wchar_t wc;
+            int len = mbtowc(&wc, s + i, MB_CUR_MAX);
+            if (len <= 0) {
+                ++width;
+                ++i;
+            } else {
+                int w = wcwidth(wc);
+                width += (w > 0) ? w : 1;
+                i += len;
+            }
+        }
+    }
+    return width;
+#endif
+}
+

--- a/examples/editor_common.h
+++ b/examples/editor_common.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,54 +17,15 @@ extern "C" {
  * relies on the real toolchain.  All functions are portable C.
  */
 
-static inline void pgm_print(const char *p)
-{
-#ifdef __AVR__
-    for (char c = pgm_read_byte(p); c; c = pgm_read_byte(++p))
-        putchar(c);
-#else
-    fputs(p, stdout);
-#endif
-}
+#define ARRAY_LEN(x) (sizeof(x) / sizeof((x)[0]))
 
-static inline void highlight(const char *line)
-{
-    if (strncmp(line, "//", 2) == 0 || line[0] == '#') {
-        printf("\x1b[33m%s\x1b[0m", line);
-        return;
-    }
-
-    for (const char *p = line; *p; ++p) {
-        if (isdigit((unsigned char)*p))
-            printf("\x1b[36m%c\x1b[0m", *p);
-        else
-            putchar(*p);
-    }
-}
-
-static inline void insert_line(char lines[][MAX_LINE_LEN], uint8_t *count,
-                               uint8_t idx, const char *text)
-{
-    if (*count >= MAX_LINES)
-        return;
-    if (idx > *count)
-        idx = *count;
-    for (uint8_t i = *count; i > idx; --i)
-        memcpy(lines[i], lines[i - 1], MAX_LINE_LEN);
-    strncpy(lines[idx], text, MAX_LINE_LEN - 1);
-    lines[idx][MAX_LINE_LEN - 1] = '\0';
-    ++*count;
-}
-
-static inline void delete_line(char lines[][MAX_LINE_LEN], uint8_t *count,
-                               uint8_t idx)
-{
-    if (idx >= *count)
-        return;
-    for (uint8_t i = idx; i + 1 < *count; ++i)
-        memcpy(lines[i], lines[i + 1], MAX_LINE_LEN);
-    --*count;
-}
+void pgm_print(const char *p);
+void highlight(const char *line);
+void insert_line(char lines[][MAX_LINE_LEN], uint8_t *count,
+                 uint8_t idx, const char *text);
+void delete_line(char lines[][MAX_LINE_LEN], uint8_t *count,
+                 uint8_t idx);
+int  display_width(const char *s, size_t byte_offset);
 
 #ifdef __cplusplus
 }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -51,21 +51,22 @@ if host_machine.cpu_family() == 'avr'
   opt_cflags += ['-fno-stack-protector']
 endif
 
+
 ned = executable(
   'ned',
-  'ned.c',
+  ['ned.c', 'editor_common.c'],
   include_directories: inc,
   link_with: libavrix,
-  c_args: opt_cflags,
+  c_args: opt_cflags + ['-DMAX_LINES=16', '-DMAX_LINE_LEN=64'],
   install: false
 )
 
 vini = executable(
   'vini',
-  'vini.c',
+  ['vini.c', 'editor_common.c'],
   include_directories: inc,
   link_with: libavrix,
-  c_args: opt_cflags,
+  c_args: opt_cflags + ['-DMAX_LINES=14', '-DMAX_LINE_LEN=64'],
   install: false
 )
 


### PR DESCRIPTION
## Summary
- factor out common runtime helpers for ned and vini
- keep prototypes/macros only in `editor_common.h`
- compile `editor_common.c` with ned and vini via Meson

## Testing
- `meson setup build` *(fails: File superlock_test.c does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6858a9b644008331a82813c26090086d