### PR TITLE
Implement meson size gate custom_target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,9 +104,15 @@ if doc_targets.length() > 0
 endif
 
 # ─────────────────────────  Size gate  ─────────────────────────────────
-size_gate = run_target(
+size_gate = custom_target(
   'size-gate',
-  command : [python, files('scripts/size_gate.py'), meson.project_build_root()],
-  depends : [fs_demo, romfs_demo, slip_demo, ned, vini],
+  input  : [fs_demo, romfs_demo, slip_demo, ned, vini],
+  output : 'size-gate.stamp',
+  command: [
+    python, files('scripts/size_gate.py'),
+    '@INPUT@',
+    '30720',
+    '@OUTPUT@'
+  ],
   console : true
 )

--- a/scripts/size_gate.py
+++ b/scripts/size_gate.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-"""Fail if any ELF in the build directory exceeds 30 kB of flash."""
+"""Flash size gate helper.
+
+This script measures the flash footprint of one or more ELF binaries using
+``avr-size``.  It fails when any binary exceeds the configured ``limit`` and
+records the measured size in the file pointed to by ``output``.
+"""
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
-
-FLASH_LIMIT = 30 * 1024  # bytes
 
 
 def flash_usage(elf: Path) -> int:
@@ -21,23 +25,42 @@ def flash_usage(elf: Path) -> int:
     return text + data
 
 
-def main(build_dir: str) -> int:
-    build = Path(build_dir)
-    elfs = sorted(build.rglob('*.elf'))
-    if not elfs:
-        print(f'[size-gate] no ELF binaries found in {build}', file=sys.stderr)
+def main(argv: list[str]) -> int:
+    """Entry point.
+
+    Parameters
+    ----------
+    argv:
+        Command-line arguments excluding the program name.  The expected
+        form is ``ELF... LIMIT OUTPUT`` where ``ELF`` denotes one or more
+        binaries to check, ``LIMIT`` is the flash ceiling in bytes and
+        ``OUTPUT`` is the file to write the final size to.
+    """
+
+    if len(argv) < 3:
+        print('usage: size_gate.py <elf> [<elf> ...] <limit> <output>',
+              file=sys.stderr)
         return 1
 
+    limit = int(argv[-2])
+    out_path = Path(argv[-1])
+    elfs = [Path(e) for e in argv[:-2]]
+
     status = 0
+    max_size = 0
     for elf in elfs:
         size = flash_usage(elf)
-        if size > FLASH_LIMIT:
-            print(f'[size-gate] {elf} : {size} bytes > {FLASH_LIMIT}', file=sys.stderr)
+        max_size = max(max_size, size)
+        if size > limit:
+            print(f'[size-gate] {elf} : {size} bytes > {limit}',
+                  file=sys.stderr)
             status = 1
         else:
             print(f'[size-gate] {elf} : {size} bytes OK')
+
+    out_path.write_text(f"{max_size}\n")
     return status
 
 
-if __name__ == '__main__':
-    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else 'build'))
+if __name__ == '__main__':  # pragma: no cover - CLI entry
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- extend `size_gate.py` to handle one or more ELF files and emit their size
- convert size-gate from a `run_target` to a `custom_target`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a9af4a888331afad4fd780903b21

## Summary by Sourcery

Extend the flash size gate script to handle multiple ELF files with a configurable limit and emit the maximum size, and integrate it into Meson as a custom_target.

New Features:
- Allow the size gate to process multiple ELF binaries against a configurable flash limit
- Write the maximum measured flash size to a specified output file

Enhancements:
- Add explicit CLI arguments for ELFs, limit, and output with usage guidance
- Expand script docstring to clarify behavior and parameter expectations

Build:
- Convert the Meson size-gate from a run_target to a custom_target with defined inputs, outputs, and command