### PR TITLE
Centralise Meson build flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build directories
-build/
+build/*
+!build/flags.meson
+!build/meson.build
 docs/build/
 docs/doxygen/
 docker/avrix.img

--- a/build/flags.meson
+++ b/build/flags.meson
@@ -1,0 +1,13 @@
+# Shared compiler and linker flags used across Avrix
+# Imported by subdirs via `subdir('build')`
+
+common_cflags = [
+  '-O2',
+  '-Wall',
+  '-Wextra',
+  '-pedantic',
+  '-std=c23'
+]
+
+# Linker flags may be extended by specific targets
+common_ldflags = []

--- a/build/meson.build
+++ b/build/meson.build
@@ -1,0 +1,13 @@
+# build/meson.build -- shared flag definitions
+
+common_cflags = [
+  '-O2',
+  '-Wall',
+  '-Wextra',
+  '-pedantic',
+  '-std=c23'
+]
+
+common_ldflags = []
+
+# File 'flags.meson' mirrors these definitions for external tooling

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -3,7 +3,7 @@ fs_demo = executable(
   'fs_demo.c',
   include_directories: inc,
   link_with: libavrix,
-  c_args: ['-Wall', '-Wextra'],
+  c_args: common_cflags,
   install: false
 )
 
@@ -12,7 +12,7 @@ romfs_demo = executable(
   'romfs_demo.c',
   include_directories: inc,
   link_with: libavrix,
-  c_args: ['-Wall', '-Wextra'],
+  c_args: common_cflags,
   install: false
 )
 
@@ -21,7 +21,7 @@ slip_demo = executable(
   'slip_demo.c',
   include_directories: inc,
   link_with: libavrix,
-  c_args: ['-Wall', '-Wextra'],
+  c_args: common_cflags,
   install: false
 )
 
@@ -42,8 +42,8 @@ if objcopy.found()
     output: 'slip_demo.hex')
 endif
 
-opt_cflags = [
-  '-Wall', '-Wextra', '-Os',
+opt_cflags = common_cflags + [
+  '-Os',
   '-ffunction-sections', '-fdata-sections'
 ]
 
@@ -74,7 +74,7 @@ if not meson.is_cross_build()
     'door_demo',
     'door_demo.c',
     include_directories: inc,
-    c_args: ['-Wall', '-Wextra'],
+  c_args: common_cflags,
     native: true,
     install: false
   )

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ project(
   ]
 )
 
+subdir('build')
+
 python = import('python').find_installation('python3')
 
 ## Include directories

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,5 @@
 # ──────────── tests/meson.build ────────────────────────────────────────
+# (flags defined in top-level build/flags.meson)
 #
 # Native build   → links tests against the complete **libavrix** stub.
 # Cross build    → compiles tests for the host CPU (`native: true`),
@@ -50,18 +51,18 @@ elif fs_mod.is_dir('/usr/lib/avr/include')
 endif
 
 # 2 · Compiler and Sanitizer Flags Setup
-common_cflags = ['-O2', '-Wall', '-Wextra', '-pedantic', '-std=c23']
-common_link_args = []
+# Start with project-wide defaults from build/flags.meson
+
 
 if not meson.is_cross_build()
   if san and cc.get_id() in ['gcc', 'clang']
     common_cflags    += ['-fsanitize=address,undefined']
-    common_link_args += ['-fsanitize=address,undefined']
+    common_ldflags += ['-fsanitize=address,undefined']
   endif
 
   if cov and cc.has_argument('-fcoverage-mapping')
     common_cflags    += ['-fprofile-instr-generate', '-fcoverage-mapping']
-    common_link_args += ['-fprofile-instr-generate', '-fcoverage-mapping']
+    common_ldflags += ['-fprofile-instr-generate', '-fcoverage-mapping']
   endif
 endif
 
@@ -108,7 +109,7 @@ foreach t : tests
     include_directories : inc_list,
     link_with           : link_target,
     c_args              : common_cflags,
-    link_args           : common_link_args,
+    link_args           : common_ldflags,
     native              : true
   )
 
@@ -130,7 +131,7 @@ if target_machine.cpu_family() == 'avr'
         s[0],
         s[1] + extra_src,
         include_directories : inc_list,
-        c_args              : ['-Os', '-std=c11', '-Wall', '-Wextra', '-pedantic']
+        c_args              : common_cflags
       )
 
       test(


### PR DESCRIPTION
## Summary
- create `build/flags.meson` and mirror it in `build/meson.build`
- add `subdir('build')` to the top-level build script
- reuse `common_cflags` throughout example and test builds
- track the build directory files via `.gitignore`

## Testing
- `meson setup builddir -Dsan=false -Dcov=false` *(fails: File superlock_test.c does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6858a9a1096883319f9f12d654ced565

## Summary by Sourcery

Centralize Meson build flags into a shared script, include it in the top-level build, and apply the common flags across example and test targets

Enhancements:
- Extract common compiler and linker flags into build/flags.meson and mirror them in build/meson.build
- Update example and test Meson scripts to use the shared common_cflags and common_ldflags variables, replacing ad-hoc c_args and link_args

Build:
- Include the build subdirectory via subdir('build') in the top-level meson.build

Chores:
- Add the build directory to .gitignore to track generated files