### PR TITLE
Introduce flash_limit meson option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Compile targets
         run: meson compile -C build
 
-      - name: Enforce size gate
+      - name: Enforce size gate (-Dflash_limit)
         run: meson compile -C build size-gate
 
       # ── 4 · Test ───────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ meson setup   build --wipe --cross-file cross/atmega328p_gcc14.cross
 meson compile -C build
 qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
 meson compile -C build flash          # flashes over /dev/ttyACM0
+meson compile -C build size-gate      # fails if firmware exceeds -Dflash_limit
 ```
+
+Customize the limit with ``meson configure build -Dflash_limit=32768``.
 
 *(LLVM, SimAVR, custom cross-file, tmux launcher, etc. retained verbatim.)*
 

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -163,6 +163,8 @@ For a *legacy* build drop ``--icf`` / ``-fipa-pta`` and switch
    qemu-system-avr -M arduino-uno -bios build/unix0.elf -nographic
    meson compile -C build flash \
         -Dflash_port=/dev/ttyACM0 -Dflash_programmer=arduino
+   meson compile -C build size-gate \
+        # fails if firmware exceeds -Dflash_limit
 
 ``-Ddebug_gdb=true`` bundles a tiny on-device GDB stub so
 ``avr-gdb`` can attach over the serial port.
@@ -170,6 +172,8 @@ For a *legacy* build drop ``--icf`` / ``-fipa-pta`` and switch
 ``cross/atmega328p_clang20.cross`` is provided for LLVM 20 users.
 ``cross/atmega32.cross`` and ``cross/atmega128.cross`` extend the
 selection to DIP‐40 and larger ATmega128 boards.
+
+Adjust the threshold via ``meson configure build -Dflash_limit=32768``.
 
 .. code-block:: bash
 

--- a/meson.build
+++ b/meson.build
@@ -106,7 +106,13 @@ endif
 # ─────────────────────────  Size gate  ─────────────────────────────────
 size_gate = run_target(
   'size-gate',
-  command : [python, files('scripts/size_gate.py'), meson.project_build_root()],
+  command : [
+    python,
+    files('scripts/size_gate.py'),
+    '--limit',
+    get_option('flash_limit'),
+    meson.project_build_root(),
+  ],
   depends : [fs_demo, romfs_demo, slip_demo, ned, vini],
   console : true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,3 +42,10 @@ option(
   value : false,
   description : 'Enable LLVM/clang-based coverage instrumentation for host unit tests'
 )
+
+option(
+  'flash_limit',
+  type : 'integer',
+  value : 30720,
+  description : 'Maximum firmware size in bytes (size-gate)'
+)


### PR DESCRIPTION
## Summary
- add `flash_limit` option in `meson_options.txt`
- pass `--limit` to `size_gate.py` in meson
- parse optional limit flag in `scripts/size_gate.py`
- reference `-Dflash_limit` in CI, README and docs

## Testing
- `python3 -m py_compile scripts/size_gate.py`
- `meson setup build --wipe` *(fails: File superlock_test.c does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6858a99e4db483318ee599abcf0b8af2

## Summary by Sourcery

Enable a configurable flash size limit by introducing a Meson option and updating the size_gate script and build/CI configurations to enforce the specified limit.

New Features:
- Introduce 'flash_limit' Meson option for configuring the maximum firmware size
- Add a --limit flag to size_gate.py to override the default flash size limit

Enhancements:
- Update size_gate script to accept limit from argument or FLASH_LIMIT environment variable
- Use the meson.get_option('flash_limit') value when invoking the size gate in Meson

Build:
- Add flash_limit option in meson_options.txt
- Modify meson.build to pass the flash_limit option to the size_gate run target

CI:
- Update CI workflow to run size-gate with the flash_limit option

Documentation:
- Document the flash_limit option in README.md and toolchain.rst