### PR TITLE
Add flash-limit toggle and shared build flags

### DIFF
--- a/build/flags.meson
+++ b/build/flags.meson
@@ -2,12 +2,18 @@
 # Imported by subdirs via `subdir('build')`
 
 common_cflags = [
-  '-O2',
+  '-pipe',
+  '-ffunction-sections',
+  '-fdata-sections',
+  '-fno-common',
+  '-Os',
   '-Wall',
   '-Wextra',
-  '-pedantic',
+  '-Wpedantic',
   '-std=c23'
 ]
 
 # Linker flags may be extended by specific targets
-common_ldflags = []
+common_ldflags = [
+  '-Wl,--gc-sections'
+]

--- a/build/meson.build
+++ b/build/meson.build
@@ -1,13 +1,19 @@
 # build/meson.build -- shared flag definitions
 
 common_cflags = [
-  '-O2',
+  '-pipe',
+  '-ffunction-sections',
+  '-fdata-sections',
+  '-fno-common',
+  '-Os',
   '-Wall',
   '-Wextra',
-  '-pedantic',
+  '-Wpedantic',
   '-std=c23'
 ]
 
-common_ldflags = []
+common_ldflags = [
+  '-Wl,--gc-sections'
+]
 
 # File 'flags.meson' mirrors these definitions for external tooling

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,9 @@ project(
 )
 
 # ── helper modules / common flags ────────────────────────────────────
-subdir('build')                      # shared flag definitions (if any)
+subdir('build')                      # shared flag definitions
+add_project_arguments(common_cflags, language : 'c')
+add_project_link_arguments(common_ldflags, language : 'c')
 python = import('python').find_installation('python3')
 
 # ── include-path logic ───────────────────────────────────────────────
@@ -99,18 +101,27 @@ endif
 # ─────────────────────────── size gate ───────────────────────────────
 # Blocks the build if any firmware ELF exceeds --limit (bytes).
 # Requires in meson_options.txt:
-#   option('flash_limit', type : 'string', value : '30720',
-#          description : 'Maximum allowed firmware size (bytes)')
+#   option('flash_limit',        type : 'boolean', value : true,
+#          description : 'Enable flash size gate when compiling firmware')
+#   option('flash_limit_bytes',  type : 'integer', value : 30720,
+#          description : 'Maximum firmware size in bytes checked by size gate')
+
+if get_option('flash_limit')
+  gate_cmd = [
+    python,
+    files('scripts/size_gate.py'),
+    '--limit', get_option('flash_limit_bytes'),
+    '@INPUT@',
+    '@OUTPUT@'
+  ]
+else
+  gate_cmd = ['true']
+endif
+
 size_gate = custom_target(
   'size-gate',
   input   : [fs_demo, romfs_demo, slip_demo, ned, vini],
   output  : 'size-gate.stamp',
-  command : [
-    python,
-    files('scripts/size_gate.py'),
-    '--limit', get_option('flash_limit'),
-    '@INPUT@',          # ELF list
-    '@OUTPUT@'
-  ],
+  command : gate_cmd,
   console : true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -45,7 +45,14 @@ option(
 
 option(
   'flash_limit',
+  type : 'boolean',
+  value : true,
+  description : 'Enable flash size gate when compiling firmware'
+)
+
+option(
+  'flash_limit_bytes',
   type : 'integer',
   value : 30720,
-  description : 'Maximum firmware size in bytes (size-gate)'
+  description : 'Maximum firmware size in bytes checked by size gate'
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,18 +51,19 @@ elif fs_mod.is_dir('/usr/lib/avr/include')
 endif
 
 # ───────────────────── 2 · Common compiler flags  ─────────────────────
-common_cflags    = ['-O2', '-Wall', '-Wextra', '-pedantic', '-std=c2x']
-common_ldflags   = []
+# Start from project-wide defaults defined in build/flags.meson
+test_cflags  = common_cflags
+test_ldflags = common_ldflags
 
 if not meson.is_cross_build()
   if san and cc.get_id() in ['gcc', 'clang']
-    common_cflags += ['-fsanitize=address,undefined']
-    common_ldflags += ['-fsanitize=address,undefined']
+    test_cflags += ['-fsanitize=address,undefined']
+    test_ldflags += ['-fsanitize=address,undefined']
   endif
 
   if cov and cc.has_argument('-fcoverage-mapping')
-    common_cflags += ['-fprofile-instr-generate', '-fcoverage-mapping']
-    common_ldflags += ['-fprofile-instr-generate', '-fcoverage-mapping']
+    test_cflags += ['-fprofile-instr-generate', '-fcoverage-mapping']
+    test_ldflags += ['-fprofile-instr-generate', '-fcoverage-mapping']
   endif
 endif
 
@@ -97,8 +98,8 @@ foreach t : tests
     t[1],
     include_directories : inc_list,
     link_with           : [link_target] + extra_libs,
-    c_args              : common_cflags,
-    link_args           : common_ldflags,
+    c_args              : test_cflags,
+    link_args           : test_ldflags,
     native              : true
   )
   test(t[0], exe)
@@ -120,7 +121,7 @@ if target_machine.cpu_family() == 'avr'
         s[0],
         s[1],
         include_directories : inc_list,
-        c_args              : common_cflags
+        c_args              : test_cflags
       )
 
       test(


### PR DESCRIPTION
## Summary
- enable a flash-size gate via new `flash_limit` option
- share common flags in `build/flags.meson`
- apply shared flags project-wide and gate firmware size check
- use shared flags from the test suite

## Testing
- `meson setup bld --wipe` *(fails: none of values ['c23'] are supported by the C compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6858b1581cc88331b4e2e6124d97150e

## Summary by Sourcery

Add a toggleable flash size gate with configurable limit and consolidate compiler/linker flags into a shared build configuration

New Features:
- Introduce a boolean `flash_limit` option to enable or disable the firmware size gate
- Add a `flash_limit_bytes` option to configure the maximum allowed firmware size

Enhancements:
- Centralize common compiler and linker flags in `build/flags.meson`
- Apply shared flags project-wide via `add_project_arguments` and `add_project_link_arguments` in the main build
- Gate the size check command to a no-op when the flash limit is disabled

Build:
- Refactor `meson.build` to import and use common flags from `build/flags.meson`

Documentation:
- Extend `meson_options.txt` with descriptions for the new flash limit options

Tests:
- Update the test suite to consume the shared compiler and linker flags