### PR TITLE
Refine editor_common header

### DIFF
--- a/examples/editor_common.h
+++ b/examples/editor_common.h
@@ -2,9 +2,6 @@
 #define EDITOR_COMMON_H
 
 #include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
 #include <stddef.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- streamline editor_common.h to only require `stdint.h` and `stddef.h`
- keep implementations in editor_common.c unchanged

## Testing
- `meson setup builddir -Dc_std=c2x` *(fails: Tried to form an absolute path to a dir in the source tree)*

------
https://chatgpt.com/codex/tasks/task_e_6858b848c30c83319f35f3a322b812e7