### PR TITLE
Fix PROGMEM ptr reads for host build

### DIFF
--- a/src/eepfs.c
+++ b/src/eepfs.c
@@ -80,19 +80,23 @@ const eepfs_file_t *eepfs_open(const char *path)
             p++;
         uint8_t count = pgm_read_byte(&dir->count);
         eepfs_entry_t ent;
+        const eepfs_entry_t *ents;
 #ifdef __AVR__
-        const eepfs_entry_t *ents =
-            (const eepfs_entry_t *)pgm_read_word(&dir->entries);
+        /* Directory tables live in flash on AVR; fetch pointer through pgm_read_word */
+        ents = (const eepfs_entry_t *)pgm_read_word(&dir->entries);
 #else
-        const eepfs_entry_t *ents = dir->entries;
+        /* Host build: PROGMEM collapses to a normal array */
+        ents = dir->entries;
 #endif
         bool found = false;
         for (uint8_t i = 0; i < count; i++) {
             memcpy_P(&ent, &ents[i], sizeof ent);
+            const char *nm;
 #ifdef __AVR__
-            const char *nm = (const char *)pgm_read_word(&ent.name);
+            /* Entry names also reside in flash */
+            nm = (const char *)pgm_read_word(&ent.name);
 #else
-            const char *nm = ent.name;
+            nm = ent.name;
 #endif
             if (eq_p(seg, nm)) {
                 found = true;

--- a/src/romfs.c
+++ b/src/romfs.c
@@ -100,19 +100,23 @@ const romfs_file_t *romfs_open(const char *path)
             p++;
         uint8_t count = pgm_read_byte(&dir->count);
         romfs_entry_t entry;
+        const romfs_entry_t *entries;
 #ifdef __AVR__
-        const romfs_entry_t *entries =
-            (const romfs_entry_t *)pgm_read_word(&dir->entries);
+        /* Directory tables are stored in program memory */
+        entries = (const romfs_entry_t *)pgm_read_word(&dir->entries);
 #else
-        const romfs_entry_t *entries = dir->entries;
+        /* Host build: arrays already reside in RAM */
+        entries = dir->entries;
 #endif
         bool found = false;
         for (uint8_t i = 0; i < count; i++) {
             memcpy_P(&entry, &entries[i], sizeof entry);
+            const char *nm;
 #ifdef __AVR__
-            const char *nm = (const char *)pgm_read_word(&entry.name);
+            /* Entry names stored in flash require pgm_read_word */
+            nm = (const char *)pgm_read_word(&entry.name);
 #else
-            const char *nm = entry.name;
+            nm = entry.name;
 #endif
             if (equal_p(seg, nm)) {
                 found = true;


### PR DESCRIPTION
## Summary
- fix PROGMEM access in `eepfs` and `romfs`
- provide comments around `pgm_read_word` for AVR
- use simple pointers when building for host

## Testing
- `meson setup bld --wipe -Dc_std=c2x` *(fails: absolute path include problem)*
- `meson test -C bld` *(fails: no build data)*

------
https://chatgpt.com/codex/tasks/task_e_6858b846bdec8331bd6571a79af0d028