### PR TITLE
Enforce fs_create name checks

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -64,18 +64,30 @@ void fs_init(void) {
     strcpy(dir_name[0], "/");
 }
 
+/**
+ * Create a new inode entry with *name* and the given *type*.
+ *
+ * Empty names are considered invalid and duplicates are rejected.
+ *
+ * @param name  NUL terminated filename to install in the directory.
+ * @param type  Inode type (1 = file, 2 = directory).
+ *
+ * @return Newly allocated inode number on success, ``-EINVAL`` for an
+ *         invalid name, ``-EEXIST`` if *name* is already present, or
+ *         ``-1`` when no inodes remain.
+ */
 int fs_create(const char *name, uint8_t type) {
-    if (name == NULL) {
+    if (name == NULL || *name == '\0') {
         return -EINVAL;
     }
 
     size_t len = strnlen(name, FS_MAX_NAME + 1);
-    if (len == 0 || len > 13) {
+    if (len == 0 || len > FS_MAX_NAME - 1) {
         return -EINVAL;
     }
 
     for (uint8_t i = 0; i < FS_NUM_INODES; ++i) {
-        if (inodes[i].type && strncmp(dir_name[i], name, FS_MAX_NAME) == 0) {
+        if (inodes[i].type && strcmp(dir_name[i], name) == 0) {
             return -EEXIST;
         }
     }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -28,8 +28,9 @@ test(
   python,
   args : [
     files('check_docs.py'),
-    '--docs-dir',   meson.project_source_root() / 'docs/source',
-    '--index-file', meson.project_source_root() / 'docs/source/index.rst',
+    '--docs-dir',   meson.current_source_dir() / '..' / 'docs' / 'source',
+    '--index-file', meson.current_source_dir() / '..' / 'docs' / 'source' /
+                     'index.rst',
     '--recursive',
   ],
   workdir : meson.project_source_root()
@@ -40,7 +41,7 @@ inc_list = [inc]
 
 # Host builds need AVR-compat headers
 if host_machine.cpu_family() != 'avr'
-  inc_list += include_directories(meson.project_source_root() / 'compat')
+  inc_list += include_directories('..' / 'compat')
 endif
 
 avr_inc = get_option('avr_inc_dir')


### PR DESCRIPTION
## Summary
- document and harden `fs_create`
- use `strcmp` and validate input name
- fix absolute path usage in test meson file

## Testing
- `meson setup builddir -Dc_std=c2x -Dflash_limit=false` *(fails: Tried to mix libraries ...)*
- `ninja -C builddir` *(fails to build due to unsupported flags)*
- `meson test -C builddir` *(fails to configure/build)*

------
https://chatgpt.com/codex/tasks/task_e_6858bac450288331afbee18f4f4dd540