### PR TITLE
Refine locale setup for examples

### DIFF
--- a/examples/editor_common.c
+++ b/examples/editor_common.c
@@ -103,7 +103,6 @@ int display_width(const char *s, size_t byte_offset)
 #else
     int width  = 0;
     size_t i   = 0;
-    setlocale(LC_CTYPE, "");
     while (i < byte_offset && s[i]) {
         if (s[i] == '\t') {
             width += 8 - (width % 8);


### PR DESCRIPTION
## Summary
- call `setlocale()` once in each editor example
- remove redundant locale setup from `display_width`

## Testing
- `meson setup bld -Dc_std=c2x` *(fails: custom_target command empty)*

------
https://chatgpt.com/codex/tasks/task_e_6858c16ff49883319db9446516ee20e5