### PR TITLE
Fix path require order

### DIFF
--- a/scripts/repo_map.js
+++ b/scripts/repo_map.js
@@ -1,8 +1,11 @@
+// Path is required before its first use to prevent a ReferenceError when
+// resolving the Tree-sitter C grammar path.
+const path = require('path');
 const Parser = require('tree-sitter');
-const TREE_SITTER_C_PATH = process.env.TREE_SITTER_C_PATH || path.resolve(__dirname, 'tree-sitter-c');
+const TREE_SITTER_C_PATH = process.env.TREE_SITTER_C_PATH ||
+  path.resolve(__dirname, 'tree-sitter-c');
 const C = require(TREE_SITTER_C_PATH);
 const fs = require('fs');
-const path = require('path');
 
 const parser = new Parser();
 parser.setLanguage(C);


### PR DESCRIPTION
## Summary
- fix `scripts/repo_map.js` by requiring `path` before it is used

## Testing
- `node scripts/repo_map.js` *(fails: Cannot find module 'tree-sitter')*

------
https://chatgpt.com/codex/tasks/task_e_6858d47edea0833198a8989dfcbd85de

## Summary by Sourcery

Fix the order of requiring the Node `path` module in scripts/repo_map.js to prevent a ReferenceError when resolving the Tree-sitter C grammar path

Bug Fixes:
- Require `path` before its first use to avoid a ReferenceError when resolving the Tree-sitter C grammar path
- Remove duplicate `path` require statement

Enhancements:
- Add comment explaining the need to require `path` before use