### PR TITLE
Add options to repo_map script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Customize the limit with ``meson configure build -Dflash_limit=32768``.
 * **Fixed-point Q8.8** helpers.
 * **Full QEMU board model** (`arduino-uno`) wired into CI.
 
+### 9 · Repository map generation
+
+The `scripts/repo_map.js` utility crawls all C sources and emits a
+`repo_map.json` description.  Custom paths may be specified via CLI
+arguments.  When omitted it defaults to `src/` and `tests/` and writes
+`repo_map.json` in the current directory.
+
+```bash
+node scripts/repo_map.js -s src -s extras -t tests -o repo_map.json
+```
+
 
 
 [1]: https://tracker.debian.org/gcc-avr "gcc-avr - Debian Package Tracker"

--- a/scripts/repo_map.js
+++ b/scripts/repo_map.js
@@ -1,8 +1,13 @@
+// -----------------------------------------------------------------------------
+// repo_map.js — gather source metadata in repo_map.json
+// -----------------------------------------------------------------------------
 const Parser = require('tree-sitter');
-const TREE_SITTER_C_PATH = process.env.TREE_SITTER_C_PATH || path.resolve(__dirname, 'tree-sitter-c');
-const C = require(TREE_SITTER_C_PATH);
 const fs = require('fs');
 const path = require('path');
+
+const TREE_SITTER_C_PATH =
+  process.env.TREE_SITTER_C_PATH || path.resolve(__dirname, 'tree-sitter-c');
+const C = require(TREE_SITTER_C_PATH);
 
 const parser = new Parser();
 parser.setLanguage(C);
@@ -29,22 +34,72 @@ const files = {};
 function scan(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, entry.name);
-    if (entry.isDirectory()) scan(fp);
-    else if (fp.endsWith('.c')) {
+    if (entry.isDirectory()) {
+      scan(fp);
+    } else if (fp.endsWith('.c')) {
       files[fp] = { functions: parseFile(fp) };
     }
   }
 }
 
-scan('src');
-scan('tests');
+// ────────────────────────────── CLI ──────────────────────────────────
+// Usage: node repo_map.js [--src dir]... [--tests dir] [--out file]
+// Multiple --src options may be given. Defaults are src/, tests/, repo_map.json
+const argv = process.argv.slice(2);
+const srcDirs = [];
+let testsDir = 'tests';
+let outFile = 'repo_map.json';
+
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  switch (arg) {
+    case '--src':
+    case '-s':
+      if (!argv[i + 1]) {
+        console.error('missing argument for --src');
+        process.exit(1);
+      }
+      srcDirs.push(argv[++i]);
+      break;
+    case '--tests':
+    case '-t':
+      if (!argv[i + 1]) {
+        console.error('missing argument for --tests');
+        process.exit(1);
+      }
+      testsDir = argv[++i];
+      break;
+    case '--out':
+    case '-o':
+      if (!argv[i + 1]) {
+        console.error('missing argument for --out');
+        process.exit(1);
+      }
+      outFile = argv[++i];
+      break;
+    default:
+      console.error(`unknown option: ${arg}`);
+      process.exit(1);
+  }
+}
+
+if (srcDirs.length === 0) {
+  srcDirs.push('src');
+}
+
+for (const dir of srcDirs) {
+  scan(dir);
+}
+scan(testsDir);
 
 const map = {
   files,
   build_system: 'meson',
   cross_files: fs.readdirSync('cross').filter(f => f.endsWith('.cross')),
-  toolchains: fs.readdirSync('cross').filter(f => f.endsWith('.cross')).map(f => f.replace('.cross','')),
-  test_suites: fs.readdirSync('tests').filter(f => f.endsWith('.c')),
+  toolchains: fs.readdirSync('cross')
+    .filter(f => f.endsWith('.cross'))
+    .map(f => f.replace('.cross', '')),
+  test_suites: fs.readdirSync(testsDir).filter(f => f.endsWith('.c')),
 };
 
-fs.writeFileSync('repo_map.json', JSON.stringify(map, null, 2));
+fs.writeFileSync(outFile, JSON.stringify(map, null, 2));


### PR DESCRIPTION
## Summary
- make `scripts/repo_map.js` take `--src`, `--tests` and `--out`
- document the new options in the README

## Testing
- `meson test -C build --print-errorlogs` *(fails: No such build data file)*

------
https://chatgpt.com/codex/tasks/task_e_6858d492cd8c8331972d1e4962d1627e