### PR TITLE
Parameterize cross directory in repo_map.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ ignored by git.
 
 The `scripts/repo_map.js` utility crawls all C sources and emits a
 `repo_map.json` description.  Custom paths may be specified via CLI
-arguments.  When omitted it defaults to `src/` and `tests/` and writes
-`repo_map.json` in the current directory.
+arguments.  When omitted it defaults to `src/` and `tests/` while
+scanning cross-files in `cross/` and writes `repo_map.json` in the
+current directory.
 
 ```bash
-node scripts/repo_map.js -s src -s extras -t tests -o repo_map.json
+node scripts/repo_map.js -s src -s extras -t tests -c cross -o repo_map.json
 ```
 
 


### PR DESCRIPTION
## Summary
- add `--cross` CLI parameter to scripts/repo_map.js
- cache cross files in a single array
- derive toolchains from cached array
- mention the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d9cfc3588331a4b3f4b40adb7472