### PR TITLE
Fix fs_roundtrip dummy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ meson configure build -Dflash_limit=32768
 Logs (`build.log`, `build.log.txt`) are produced by CI (or manually with
 `meson compile --log-file build.log | tee build.log.txt`) and ignored by git.
 
+### 2.1 · Developer packages
+
+Install host utilities for debugging and documentation:
+
+```bash
+sudo apt install -y valgrind linux-tools-common linux-tools-generic
+```
+
+See :ref:`toolchain-setup` for a full list including Meson, Doxygen and
+Sphinx helpers.
+
 ---
 
 ## 3 · What you get

--- a/cross/atmega328p_gcc14.cross
+++ b/cross/atmega328p_gcc14.cross
@@ -38,25 +38,29 @@ c_args = [
   '-DF_CPU=16000000UL',
 
   # Size-first optimisation
-  '-Oz',                               # smallest code
-  '-flto',                             # GCC 14 Thin-LTO by default
-  '-mrelax', '-mcall-prologues',       # shrink jumps & prologues
-  '-fdata-sections', '-ffunction-sections',
+  '-Oz',
+  '-flto',
+  '-mrelax',
+  '-mcall-prologues',
+  '-fdata-sections',
+  '-ffunction-sections',
   '-fmerge-all-constants',
-  '-fno-ident',                        # drop GCC version string
+  '-fno-ident',
 
   # Remove unused runtime features
-  '-fno-exceptions', '-fno-rtti',
-  '-fno-unwind-tables', '-fno-asynchronous-unwind-tables',
+  '-fno-exceptions',
+  '-fno-rtti',
+  '-fno-unwind-tables',
+  '-fno-asynchronous-unwind-tables',
   '-fno-stack-protector'
 ]
 
 c_link_args = [
   '-mmcu=atmega328p',
   '-flto',
-  '-Wl,--gc-sections',                 # dead-code elimination
-  '-Wl,--icf=safe',                    # identical code folding
-  '-Wl,--relax'                        # linker relaxation pass
+  '-Wl,--gc-sections',
+  '-Wl,--icf=safe',
+  '-Wl,--relax'
 ]
 
 [built-in options]

--- a/docs/source/toolchain.rst
+++ b/docs/source/toolchain.rst
@@ -120,7 +120,7 @@ See `Ask Ubuntu <https://askubuntu.com/>`_ for background.
 
    sudo apt install -y meson ninja-build doxygen python3-sphinx simavr \
                       python3-pip cloc cscope exuberant-ctags cppcheck graphviz \
-                      nodejs npm
+                      nodejs npm valgrind linux-tools-common linux-tools-generic
    pip3 install --user breathe exhale sphinx-rtd-theme
    npm  install  -g   prettier
    # offline? use --no-python with setup.sh and skip the two lines above

--- a/tests/fs_roundtrip.c
+++ b/tests/fs_roundtrip.c
@@ -8,7 +8,8 @@ int main(void)
     fs_init();
 
     /* reserve block zero */
-    int dummy = fs_create("dummy", 1);
+    /* Reserve block zero for metadata sanity */
+    (void)fs_create("dummy", 1);
     file_t d;
     assert(fs_open("dummy", &d) == 0);
     char c = 'x';


### PR DESCRIPTION
## Summary
- remove an unused `dummy` variable from `fs_roundtrip`
- add linux-tools and valgrind instructions to README and docs
- trim comments in `atmega328p_gcc14.cross`

## Testing
- `meson compile -C build`
- `meson test -C build`
- `meson test -C build --wrap "valgrind --leak-check=full"`


------
https://chatgpt.com/codex/tasks/task_e_68599f6d8b608331959ad71ea5003643